### PR TITLE
Add README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 GoEmqutiti Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# GoEmqutiti
+
+GoEmqutiti is a terminal based MQTT client built with [Bubble Tea](https://github.com/charmbracelet/bubbletea). It connects to a broker defined in `~/.emqutiti/config.toml` and provides a simple interface for publishing and subscribing to messages.
+
+## Installation
+
+1. Clone this repository.
+
+```bash
+git clone <repo-url>
+cd goemqutiti
+```
+
+2. Build the application:
+
+```bash
+go build
+```
+
+This will produce a `goemqutiti` binary in the current directory.
+
+## Usage
+
+Run the built binary (or use `go run .`) to start the TUI application:
+
+```bash
+./goemqutiti
+```
+
+The client expects a configuration file at `~/.emqutiti/config.toml` describing connection profiles. A minimal configuration looks like:
+
+```toml
+default_profile = "local"
+
+[[profiles]]
+name = "local"
+broker = "tcp://localhost:1883"
+client_id = "goemqutiti"
+username = "user"
+password = "keyring:emqutiti-local/user"
+```
+
+Passwords can be stored securely using the operating system keyring. You may also set the `MQTT_PASSWORD` environment variable to override the stored password at runtime.
+
+In the interface:
+
+- **Tab** switches between the topic and message fields.
+- **Enter** subscribes to a topic the first time and publishes messages afterwards.
+- **Ctrl+C** or **q** exits the program.
+
+## License
+
+This project is licensed under the terms of the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- add project documentation in `README.md`
- include an MIT license file

## Testing
- `go test ./...` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68839102d2d08324b6043242a1c68d05