### PR TITLE
Rename MQTT client parameter

### DIFF
--- a/mqttclient.go
+++ b/mqttclient.go
@@ -11,10 +11,10 @@ type MQTTClient struct {
 	Client mqtt.Client
 }
 
-func NewMQTTClient(broker, clientId, username string, password string) (*MQTTClient, error) {
+func NewMQTTClient(broker, clientID, username string, password string) (*MQTTClient, error) {
 	opts := mqtt.NewClientOptions()
 	opts.AddBroker(broker)
-	opts.SetClientID(clientId)
+	opts.SetClientID(clientID)
 	opts.SetUsername(username)
 
 	// Convert password to string only when setting it in the options


### PR DESCRIPTION
## Summary
- rename `clientId` parameter to `clientID`
- ensure `NewMQTTClient` uses the updated parameter

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883913086b88324802230b60af42c4c