### PR TITLE
Handle missing keyring entries when loading profiles

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -210,7 +210,10 @@ func LoadFromConfig(filePath string) (*Connections, error) {
 		if strings.HasPrefix(password, "keyring:") {
 			keyringPassword, err := retrievePasswordFromKeyring(password)
 			if err != nil {
-				return nil, err
+				// Do not fail if the keyring entry is missing
+				fmt.Println("Warning:", err)
+				connections.Profiles[i].Password = ""
+				continue
 			}
 			// Update the password in the profile
 			connections.Profiles[i].Password = keyringPassword
@@ -218,4 +221,16 @@ func LoadFromConfig(filePath string) (*Connections, error) {
 	}
 
 	return &connections, nil
+}
+
+// LoadProfiles updates c with profiles from the config file. It logs errors but
+// leaves c unchanged on failure.
+func (c *Connections) LoadProfiles(filePath string) {
+	loaded, err := LoadFromConfig(filePath)
+	if err != nil {
+		fmt.Println("Warning:", err)
+		return
+	}
+	c.DefaultProfileName = loaded.DefaultProfileName
+	c.Profiles = loaded.Profiles
 }

--- a/main.go
+++ b/main.go
@@ -54,15 +54,9 @@ func main() {
 	// Set log output to file
 	log.SetOutput(logFile)
 
-	// Load configuration
-	config, err := LoadFromConfig("")
-	if err != nil {
-		log.Fatalf("Failed to load configuration: %v", err)
-	}
-
 	// Start Bubble Tea UI without connecting. The user can choose a profile
 	// from the connection manager once the program starts.
-	initial := initialModel(config)
+	initial := initialModel(nil)
 	initial.mode = modeConnections
 	p := tea.NewProgram(initial)
 	if _, err := p.Run(); err != nil {

--- a/ui.go
+++ b/ui.go
@@ -73,6 +73,7 @@ func initialModel(conns *Connections) model {
 		connModel = *conns
 	} else {
 		connModel = NewConnectionsModel()
+		connModel.LoadProfiles("")
 	}
 	connModel.ConnectionsList.SetShowStatusBar(false)
 	items := []list.Item{}
@@ -124,6 +125,12 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 				m.messages = append(m.messages, fmt.Sprintf("Published to %s: %s", topic, payload))
 			}
 		case "m":
+			m.connections.LoadProfiles("")
+			items := []list.Item{}
+			for _, p := range m.connections.Profiles {
+				items = append(items, connectionItem{title: p.Name})
+			}
+			m.connections.ConnectionsList.SetItems(items)
 			m.mode = modeConnections
 		}
 	}


### PR DESCRIPTION
## Summary
- load connection profiles lazily in the UI instead of at startup
- don't fail if keyring entries are missing when loading configuration
- add helper to refresh connection profiles

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883b7e174808324ac9749e9d8fdf07c