### PR TITLE
Improve UI usability and add history log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,13 @@
 - Run `go vet ./...` and attempt `go test ./...` before committing.
 
 ## Agent Notes
-The TUI runs fullscreen with colorful borders. Press `m` to open the connection manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring.
+The TUI runs fullscreen with colorful borders. Press `Ctrl+M` to open the connection manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring.
+
+### Recent Experience
+- Keyboard shortcuts bound to plain letters can interfere with text entry. Use `Ctrl` combinations for global actions.
+- Provide both keyboard and mouse interaction for lists and chips to keep the UI consistent.
+- Favor multi-line text areas where users might paste formatted data.
+- Always consider usability and look for ways to improve it.
 
 ## Test Info
 `ExampleSet_manual` in `keyring_util_test.go` requires a real keyring. It does not run during `go test ./...` and can be executed manually if needed.


### PR DESCRIPTION
## Summary
- display recent status and messages using a scrollable history list
- switch message entry to a textarea for multi‑line input
- use Ctrl+M/T/P shortcuts so typing text doesn't trigger views
- enable copying history entries with Ctrl+Y
- document lessons learned in `AGENTS.md`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883e1d7399c8324b0cc5a2ee46f8f1a