### PR TITLE
Improve UI responsiveness and history scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In the interface:
 - **Ctrl+T** manages subscribed topics.
 - **Ctrl+P** manages stored payloads.
 - **Ctrl+C** copies the currently selected history entry.
+- **Esc** navigates back within menus without quitting.
 - **Ctrl+D** exits the program.
 
 ## License

--- a/model.go
+++ b/model.go
@@ -122,7 +122,7 @@ func initialModel(conns *Connections) model {
 	ta.Blur()
 	ta.Cursor.Style = noCursor
 	ta.SetWidth(80)
-	ta.SetHeight(4)
+	ta.SetHeight(6)
 	ta.FocusedStyle.CursorLine = focusedStyle
 	ta.BlurredStyle.CursorLine = blurredStyle
 

--- a/update.go
+++ b/update.go
@@ -203,7 +203,12 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 	var cmdMsg tea.Cmd
 	m.messageInput, cmdMsg = m.messageInput.Update(msg)
 
-	return m, tea.Batch(cmd, cmdMsg, listenStatus(m.statusChan))
+	var histCmd tea.Cmd
+	if m.focusIndex > 1 {
+		m.history, histCmd = m.history.Update(msg)
+	}
+
+	return m, tea.Batch(cmd, cmdMsg, histCmd, listenStatus(m.statusChan))
 }
 
 func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
@@ -409,6 +414,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.connections.ConnectionsList.SetSize(msg.Width-4, msg.Height-6)
+		m.topicInput.Width = msg.Width - 6
+		m.messageInput.SetWidth(msg.Width - 6)
+		m.history.SetSize(msg.Width-4, msg.Height/3)
 		return m, nil
 	}
 

--- a/views.go
+++ b/views.go
@@ -25,7 +25,6 @@ func (m model) viewClient() string {
 	}
 	topicsBox := borderStyle.Copy().Width(m.width - 4).Render("Topics:\n" + lipgloss.JoinHorizontal(lipgloss.Top, chips...))
 
-	m.history.SetSize(m.width-4, m.height/3)
 	messagesBox := legendBox(m.history.View(), "History (Ctrl+C copy)", m.width-4)
 
 	inputs := lipgloss.JoinVertical(lipgloss.Left,


### PR DESCRIPTION
## Summary
- allow resizing of text inputs and history list when the window size changes
- enable history scrolling with keyboard when inputs are not focused
- enlarge the message textarea
- document Esc key behaviour

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883f4ee90dc8324b69c7bf63c1182d2