### PR TITLE
Improve controls and pane styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Run `go vet ./...` and attempt `go test ./...` before committing.
 
 ## Agent Notes
-The TUI runs fullscreen with colorful borders. Press `Ctrl+M` to open the connection manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring.
+The TUI runs fullscreen with colorful borders. Press `Ctrl+M` to open the connection manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused.
 
 ### Recent Experience
 - Keyboard shortcuts bound to plain letters can interfere with text entry. Use `Ctrl` combinations for global actions.

--- a/README.md
+++ b/README.md
@@ -44,15 +44,18 @@ Passwords can be stored securely using the operating system keyring. You may als
 
 In the interface:
 
- - **Tab** switches between the topic and message fields.
- - **Enter** subscribes to a topic when the topic field is focused.
- - **Ctrl+S** publishes the message currently in the editor.
+- **Tab** switches between the topic and message fields.
+- **Enter** subscribes to a topic when the topic field is focused.
+- **Ctrl+S** publishes the message currently in the editor.
+- **Ctrl+Enter** also publishes the current message.
 - **Ctrl+M** opens the connection manager where you can add, edit or delete MQTT profiles.
 - **Ctrl+T** manages subscribed topics.
 - **Ctrl+P** manages stored payloads.
 - **Ctrl+C** copies the currently selected history entry.
 - **Esc** navigates back within menus without quitting.
 - **Ctrl+D** exits the program.
+- Left-click a topic chip to toggle it and middle-click to remove it.
+- Clicking on any pane or input field focuses it.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,7 @@ This document tracks the tasks and goals for developing the GoEmqutiti MQTT clie
 ---
 
 ## **3. General Features**
-- [ ] Implement keyboard shortcuts for navigation and actions.
+ - [ ] Implement keyboard shortcuts for navigation and actions. (Ctrl+S or Ctrl+Enter to publish messages)
 - [ ] Add error handling for failed connections or invalid inputs.
 - [ ] Persist all data securely between application runs.
 - [ ] Support dynamic updates from the MQTT broker (real-time message logging).

--- a/styles.go
+++ b/styles.go
@@ -12,11 +12,20 @@ var (
 	cursorStyle  = focusedStyle
 	noCursor     = lipgloss.NewStyle()
 	borderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1)
-	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63"))
+	greenBorder  = borderStyle.Copy().BorderForeground(lipgloss.Color("34"))
+	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
 	chipInactive = chipStyle.Copy().Foreground(lipgloss.Color("240"))
 )
 
 func legendBox(content, label string, width int) string {
+	return legendStyledBox(content, label, width, borderStyle)
+}
+
+func legendGreenBox(content, label string, width int) string {
+	return legendStyledBox(content, label, width, greenBorder)
+}
+
+func legendStyledBox(content, label string, width int, style lipgloss.Style) string {
 	b := lipgloss.RoundedBorder()
 	top := b.TopLeft + " " + label + " " + strings.Repeat(b.Top, width-lipgloss.Width(label)-3) + b.TopRight
 	bottom := b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight
@@ -25,5 +34,5 @@ func legendBox(content, label string, width int) string {
 		lines[i] = b.Left + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l) + b.Right
 	}
 	middle := strings.Join(lines, "\n")
-	return top + "\n" + middle + "\n" + bottom
+	return style.Render(top + "\n" + middle + "\n" + bottom)
 }

--- a/update.go
+++ b/update.go
@@ -102,7 +102,7 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 			if m.focusIndex == 2 && len(m.topics) > 0 {
 				m.selectedTopic = (m.selectedTopic + 1) % len(m.topics)
 			}
-		case "ctrl+s":
+		case "ctrl+s", "ctrl+enter":
 			if m.focusIndex == 1 {
 				payload := m.messageInput.Value()
 				for _, t := range m.topics {
@@ -174,6 +174,19 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 			m.history, cmd = m.history.Update(msg)
 			return m, tea.Batch(cmd, listenStatus(m.statusChan))
 		}
+		if msg.Type == tea.MouseLeft {
+			if msg.Y > m.height-8 {
+				m.focusIndex = 1
+				m.topicInput.Blur()
+				m.messageInput.Focus()
+			} else if msg.Y > m.height-14 {
+				m.focusIndex = 0
+				m.topicInput.Focus()
+				m.messageInput.Blur()
+			} else {
+				m.focusIndex = 2
+			}
+		}
 		if m.focusIndex == 2 {
 			row := 4
 			if msg.Y == row {
@@ -189,7 +202,7 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 						m.selectedTopic = i
 						if msg.Type == tea.MouseLeft {
 							m.topics[i].active = !m.topics[i].active
-						} else if msg.Type == tea.MouseRight {
+						} else if msg.Type == tea.MouseMiddle {
 							m.topics = append(m.topics[:i], m.topics[i+1:]...)
 							if i >= len(m.topics) {
 								m.selectedTopic = len(m.topics) - 1

--- a/views.go
+++ b/views.go
@@ -8,9 +8,9 @@ import (
 )
 
 func (m model) viewClient() string {
-	header := borderStyle.Copy().Width(m.width - 4).Render("GoEmqutiti - MQTT Client")
-	info := borderStyle.Copy().Width(m.width - 4).Render("Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads")
-	conn := borderStyle.Copy().Width(m.width - 4).Render("Connection: " + m.connection)
+	header := legendBox("GoEmqutiti - MQTT Client", "App", m.width-4)
+	info := legendBox("Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads", "Help", m.width-4)
+	conn := legendBox(m.connection, "Connection", m.width-4)
 
 	var chips []string
 	for i, t := range m.topics {
@@ -23,23 +23,20 @@ func (m model) viewClient() string {
 		}
 		chips = append(chips, st.Render(t.title))
 	}
-	topicsBox := borderStyle.Copy().Width(m.width - 4).Render("Topics:\n" + lipgloss.JoinHorizontal(lipgloss.Top, chips...))
+	topicsBox := legendBox(lipgloss.JoinHorizontal(lipgloss.Top, chips...), "Topics", m.width-4)
 
-	messagesBox := legendBox(m.history.View(), "History (Ctrl+C copy)", m.width-4)
+	messagesBox := legendGreenBox(m.history.View(), "History (Ctrl+C copy)", m.width-4)
 
-	inputs := lipgloss.JoinVertical(lipgloss.Left,
-		"Topic:\n"+m.topicInput.View(),
-		"Message:\n"+m.messageInput.View(),
-	)
-	inputsBox := borderStyle.Copy().Width(m.width - 4).Render(inputs)
+	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-4)
+	messageBox := legendBox(m.messageInput.View(), "Message", m.width-4)
+
+	inputsBox := lipgloss.JoinVertical(lipgloss.Left, topicBox, messageBox)
 
 	var payloadLines []string
 	for topic, payload := range m.payloads {
 		payloadLines = append(payloadLines, fmt.Sprintf("- %s: %s", topic, payload))
 	}
-	payloadHelp := "Stored Payloads (press Ctrl+P to manage):"
-	payloadBox := borderStyle.Copy().Width(m.width - 4).Render(payloadHelp + "\n" + strings.Join(payloadLines, "\n"))
-
+	payloadBox := legendBox(strings.Join(payloadLines, "\n"), "Payloads", m.width-4)
 	content := lipgloss.JoinVertical(lipgloss.Left, header, info, conn, topicsBox, messagesBox, inputsBox, payloadBox)
 	return lipgloss.NewStyle().Width(m.width).Height(m.height).Padding(1, 1).Render(content)
 }


### PR DESCRIPTION
## Summary
- add Ctrl+Enter to publish messages
- use green legend box for history
- add chip styling and mouse focus handling
- update documentation and agent notes

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883fb7745608324b0063de7968b41f0