### PR TITLE
Fix focus navigation and UI layout

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -17,15 +17,22 @@ var (
 	chipInactive = chipStyle.Copy().Foreground(lipgloss.Color("240"))
 )
 
-func legendBox(content, label string, width int) string {
-	return legendStyledBox(content, label, width, borderStyle)
+func legendBox(content, label string, width int, focused bool) string {
+	color := lipgloss.Color("63")
+	if focused {
+		color = lipgloss.Color("205")
+	}
+	return legendStyledBox(content, label, width, color)
 }
 
 func legendGreenBox(content, label string, width int) string {
-	return legendStyledBox(content, label, width, greenBorder)
+	return legendStyledBox(content, label, width, lipgloss.Color("34"))
 }
 
-func legendStyledBox(content, label string, width int, style lipgloss.Style) string {
+func legendStyledBox(content, label string, width int, color lipgloss.Color) string {
+	if width < lipgloss.Width(label)+4 {
+		width = lipgloss.Width(label) + 4
+	}
 	b := lipgloss.RoundedBorder()
 	top := b.TopLeft + " " + label + " " + strings.Repeat(b.Top, width-lipgloss.Width(label)-3) + b.TopRight
 	bottom := b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight
@@ -34,5 +41,5 @@ func legendStyledBox(content, label string, width int, style lipgloss.Style) str
 		lines[i] = b.Left + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l) + b.Right
 	}
 	middle := strings.Join(lines, "\n")
-	return style.Render(top + "\n" + middle + "\n" + bottom)
+	return lipgloss.NewStyle().Foreground(color).Render(top + "\n" + middle + "\n" + bottom)
 }

--- a/update.go
+++ b/update.go
@@ -149,6 +149,16 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 				}
 			} else if m.focusIndex == 2 && m.selectedTopic >= 0 && m.selectedTopic < len(m.topics) {
 				m.topics[m.selectedTopic].active = !m.topics[m.selectedTopic].active
+			} else if m.focusIndex > 1 {
+				// Ctrl+M sends the same code as enter, so treat enter as the connection shortcut when not editing fields
+				m.connections.LoadProfiles("")
+				items := []list.Item{}
+				for _, p := range m.connections.Profiles {
+					items = append(items, connectionItem{title: p.Name})
+				}
+				m.connections.ConnectionsList.SetItems(items)
+				m.saveCurrent()
+				m.mode = modeConnections
 			}
 		case "d":
 			if m.focusIndex == 2 && m.selectedTopic >= 0 && m.selectedTopic < len(m.topics) {

--- a/views.go
+++ b/views.go
@@ -8,9 +8,9 @@ import (
 )
 
 func (m *model) viewClient() string {
-	header := legendBox("GoEmqutiti - MQTT Client", "App", m.width-4)
-	info := legendBox("Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads", "Help", m.width-4)
-	conn := legendBox(m.connection, "Connection", m.width-4)
+	header := legendBox("GoEmqutiti - MQTT Client", "App", m.width-4, false)
+	info := legendBox("Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads", "Help", m.width-4, false)
+	conn := legendBox(m.connection, "Connection", m.width-4, false)
 
 	var chips []string
 	for i, t := range m.topics {
@@ -23,12 +23,12 @@ func (m *model) viewClient() string {
 		}
 		chips = append(chips, st.Render(t.title))
 	}
-	topicsBox := legendBox(lipgloss.JoinHorizontal(lipgloss.Top, chips...), "Topics", m.width-4)
+	topicsBox := legendBox(lipgloss.JoinHorizontal(lipgloss.Top, chips...), "Topics", m.width-4, m.focusIndex == 2)
 
 	messagesBox := legendGreenBox(m.history.View(), "History (Ctrl+C copy)", m.width-4)
 
-	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-4)
-	messageBox := legendBox(m.messageInput.View(), "Message", m.width-4)
+	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-4, m.focusIndex == 0)
+	messageBox := legendBox(m.messageInput.View(), "Message", m.width-4, m.focusIndex == 1)
 
 	inputsBox := lipgloss.JoinVertical(lipgloss.Left, topicBox, messageBox)
 
@@ -36,7 +36,7 @@ func (m *model) viewClient() string {
 	for topic, payload := range m.payloads {
 		payloadLines = append(payloadLines, fmt.Sprintf("- %s: %s", topic, payload))
 	}
-	payloadBox := legendBox(strings.Join(payloadLines, "\n"), "Payloads", m.width-4)
+	payloadBox := legendBox(strings.Join(payloadLines, "\n"), "Payloads", m.width-4, false)
 	content := lipgloss.JoinVertical(lipgloss.Left, header, info, conn, topicsBox, messagesBox, inputsBox, payloadBox)
 
 	y := 1


### PR DESCRIPTION
## Summary
- highlight focused input borders
- ensure clicking and tabbing work by tracking focus state
- fix connection manager shortcut when Ctrl+M is detected as Enter
- draw legend boxes with a single border

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688488334c8c8324a8717e450ed61689