### PR TITLE
Fix focus map for message textarea

### DIFF
--- a/focus_test.go
+++ b/focus_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that setFocus correctly focuses the message input
+func TestSetFocusMessage(t *testing.T) {
+	m := initialModel(nil)
+	if m.messageInput.Focused() {
+		t.Fatalf("message input should start blurred")
+	}
+	cmd := m.setFocus("message")
+	if !m.messageInput.Focused() {
+		t.Fatalf("message input not focused after setFocus")
+	}
+	if m.focusIndex != 1 {
+		t.Fatalf("focusIndex expected 1, got %d", m.focusIndex)
+	}
+	if cmd == nil {
+		t.Fatalf("expected non-nil command from setFocus")
+	}
+}
+
+// Test that pressing Tab cycles focus from topic to message
+func TestTabCyclesToMessage(t *testing.T) {
+	m := initialModel(nil)
+	if m.focusIndex != 0 {
+		t.Fatalf("initial focus index should be 0")
+	}
+	msg := tea.KeyMsg{Type: tea.KeyTab}
+	_, cmd := m.Update(msg)
+	if !m.messageInput.Focused() {
+		t.Fatalf("message input should be focused after tab")
+	}
+	if m.focusIndex != 1 {
+		t.Fatalf("focus index should be 1 after tab, got %d", m.focusIndex)
+	}
+	if cmd == nil {
+		t.Fatalf("update should return a command")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	// from the connection manager once the program starts.
 	initial := initialModel(nil)
 	initial.mode = modeConnections
-	p := tea.NewProgram(&initial, tea.WithMouseAllMotion(), tea.WithAltScreen())
+	p := tea.NewProgram(initial, tea.WithMouseAllMotion(), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		log.Fatalf("Error running program: %v", err)
 	}

--- a/model.go
+++ b/model.go
@@ -116,7 +116,7 @@ type model struct {
 	focusOrder []string
 }
 
-func initialModel(conns *Connections) model {
+func initialModel(conns *Connections) *model {
 	ti := textinput.New()
 	ti.Placeholder = "Enter Topic"
 	ti.Focus()
@@ -167,7 +167,7 @@ func initialModel(conns *Connections) model {
 
 	order := []string{"topic", "message", "topics"}
 
-	m := model{
+	m := &model{
 		history:       hist,
 		payloads:      make(map[string]string),
 		topicInput:    ti,


### PR DESCRIPTION
## Summary
- return pointer from `initialModel` so focus map keeps valid pointers
- update main.go to use pointer model
- add tests covering `setFocus` and tab focus cycling

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68849ad2b2148324a4ffa45cf0874bed