### PR TITLE
Remove extra headers from TUI

### DIFF
--- a/model.go
+++ b/model.go
@@ -153,7 +153,10 @@ func initialModel(conns *Connections) *model {
 	}
 	connModel.ConnectionsList.SetItems(items)
 
-	hist := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
+	histDelegate := list.NewDefaultDelegate()
+	histDelegate.ShowDescription = false
+	histDelegate.SetSpacing(0)
+	hist := list.New([]list.Item{}, histDelegate, 0, 0)
 	hist.SetShowStatusBar(false)
 	hist.SetShowPagination(false)
 	hist.DisableQuitKeybindings()

--- a/styles.go
+++ b/styles.go
@@ -15,6 +15,7 @@ var (
 	greenBorder  = borderStyle.BorderForeground(lipgloss.Color("34"))
 	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
 	chipInactive = chipStyle.Foreground(lipgloss.Color("240"))
+	infoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).PaddingLeft(1)
 )
 
 func legendBox(content, label string, width int, focused bool) string {

--- a/update.go
+++ b/update.go
@@ -472,9 +472,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.connections.ConnectionsList.SetSize(msg.Width-4, msg.Height-6)
 		m.topicInput.Width = msg.Width - 6
 		m.messageInput.SetWidth(msg.Width - 6)
-		m.history.SetSize(msg.Width-4, msg.Height/3)
+		m.history.SetSize(msg.Width-4, (msg.Height-1)/3)
 		m.viewport.Width = msg.Width
-		m.viewport.Height = msg.Height
+		m.viewport.Height = msg.Height - 1
 		return m, nil
 	}
 

--- a/views.go
+++ b/views.go
@@ -29,9 +29,7 @@ func wrapChips(chips []string, width int) string {
 }
 
 func (m *model) viewClient() string {
-	header := legendBox("GoEmqutiti - MQTT Client", "App", m.width-4, false)
-	info := legendBox("Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads", "Help", m.width-4, false)
-	conn := legendBox(m.connection, "Connection", m.width-4, false)
+	infoLine := infoStyle.Render("Info: Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads. " + m.connection)
 
 	var chips []string
 	for i, t := range m.topics {
@@ -58,12 +56,9 @@ func (m *model) viewClient() string {
 		payloadLines = append(payloadLines, fmt.Sprintf("- %s: %s", topic, payload))
 	}
 	payloadBox := legendBox(strings.Join(payloadLines, "\n"), "Payloads", m.width-4, false)
-	content := lipgloss.JoinVertical(lipgloss.Left, header, info, conn, topicsBox, messagesBox, inputsBox, payloadBox)
+	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, messagesBox, inputsBox, payloadBox)
 
 	y := 1
-	y += lipgloss.Height(header)
-	y += lipgloss.Height(info)
-	y += lipgloss.Height(conn)
 	m.elemPos["topics"] = y
 	y += lipgloss.Height(topicsBox)
 	y += lipgloss.Height(messagesBox)
@@ -74,8 +69,8 @@ func (m *model) viewClient() string {
 	box := lipgloss.NewStyle().Width(m.width).Padding(1, 1).Render(content)
 	m.viewport.SetContent(box)
 	m.viewport.Width = m.width
-	m.viewport.Height = m.height
-	return m.viewport.View()
+	m.viewport.Height = m.height - 1
+	return lipgloss.JoinVertical(lipgloss.Left, infoLine, m.viewport.View())
 }
 
 func (m model) viewConnections() string {


### PR DESCRIPTION
## Summary
- trim history list rows
- show a compact info line instead of three header boxes
- resize viewport to keep info line visible

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68849f25bfd883249dc606c4b0fe47c6