### PR TITLE
Implement topic chip fixes

### DIFF
--- a/mqttclient.go
+++ b/mqttclient.go
@@ -89,3 +89,12 @@ func (m *MQTTClient) Subscribe(topic string, qos byte, callback mqtt.MessageHand
 	}
 	return nil
 }
+
+func (m *MQTTClient) Unsubscribe(topic string) error {
+	token := m.Client.Unsubscribe(topic)
+	token.Wait()
+	if token.Error() != nil {
+		return fmt.Errorf("unsubscribe failed: %w", token.Error())
+	}
+	return nil
+}

--- a/views.go
+++ b/views.go
@@ -9,21 +9,21 @@ import (
 
 func wrapChips(chips []string, width int) string {
 	var lines []string
-	line := ""
+	var row []string
 	cur := 0
 	for _, c := range chips {
 		cw := lipgloss.Width(c)
-		if cur+cw > width && line != "" {
-			lines = append(lines, line)
-			line = c
+		if cur+cw > width && len(row) > 0 {
+			lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, row...))
+			row = []string{c}
 			cur = cw
 		} else {
-			line += c
+			row = append(row, c)
 			cur += cw
 		}
 	}
-	if line != "" {
-		lines = append(lines, line)
+	if len(row) > 0 {
+		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, row...))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -51,12 +51,7 @@ func (m *model) viewClient() string {
 
 	inputsBox := lipgloss.JoinVertical(lipgloss.Left, topicBox, messageBox)
 
-	var payloadLines []string
-	for topic, payload := range m.payloads {
-		payloadLines = append(payloadLines, fmt.Sprintf("- %s: %s", topic, payload))
-	}
-	payloadBox := legendBox(strings.Join(payloadLines, "\n"), "Payloads", m.width-4, false)
-	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, messagesBox, inputsBox, payloadBox)
+	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, messagesBox, inputsBox)
 
 	y := 1
 	m.elemPos["topics"] = y


### PR DESCRIPTION
## Summary
- handle wrapping of topic chips properly
- add MQTT unsubscribe helper
- support mouse actions for topic chips
- track and toggle topics with helper methods
- remove payload display from the client view

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884a3a1cad08324bcdaa1dc1988e22b