### PR TITLE
Fix connection shortcut and topic focus

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -39,7 +39,7 @@ func legendStyledBox(content, label string, width int, color lipgloss.Color) str
 		width = lipgloss.Width(label) + 4
 	}
 	b := lipgloss.RoundedBorder()
-	top := b.TopLeft + " " + label + " " + strings.Repeat(b.Top, width-lipgloss.Width(label)-3) + b.TopRight
+	top := b.TopLeft + " " + label + " " + strings.Repeat(b.Top, width-lipgloss.Width(label)-4) + b.TopRight
 	bottom := b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight
 	lines := strings.Split(content, "\n")
 	for i, l := range lines {

--- a/update.go
+++ b/update.go
@@ -164,7 +164,6 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 					}
 					m.appendHistory(topic, "", "log", fmt.Sprintf("Subscribed to topic: %s", topic))
 					m.topicInput.SetValue("")
-					cmds = append(cmds, m.setFocus("message"))
 				}
 			} else if m.focusOrder[m.focusIndex] == "topics" && m.selectedTopic >= 0 && m.selectedTopic < len(m.topics) {
 				m.toggleTopic(m.selectedTopic)
@@ -210,9 +209,11 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		}
 	case tea.MouseMsg:
 		if msg.Type == tea.MouseWheelUp || msg.Type == tea.MouseWheelDown {
-			var hCmd tea.Cmd
-			m.history, hCmd = m.history.Update(msg)
-			cmds = append(cmds, hCmd)
+			if m.focusOrder[m.focusIndex] == "history" {
+				var hCmd tea.Cmd
+				m.history, hCmd = m.history.Update(msg)
+				cmds = append(cmds, hCmd)
+			}
 		}
 		if msg.Type == tea.MouseLeft {
 			cmds = append(cmds, m.focusFromMouse(msg.Y))


### PR DESCRIPTION
## Summary
- keep focus on the topic field after pressing Enter
- switch to the connection manager with `Ctrl+M`
- correct legend box border width
- update shortcut info and docs

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884b3ad6f6c83248fbafb29c1a2eb4d