### PR TITLE
Switch to Ctrl+B for broker manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Run `go vet ./...` and attempt `go test ./...` before committing.
 
 ## Agent Notes
-The TUI runs fullscreen with colorful borders. Press `Ctrl+M` to open the connection manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused.
+The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused.
 
 ### Recent Experience
 - Keyboard shortcuts bound to plain letters can interfere with text entry. Use `Ctrl` combinations for global actions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoEmqutiti
 
-GoEmqutiti is a terminal based MQTT client built with [Bubble Tea](https://github.com/charmbracelet/bubbletea). It loads connection profiles from `~/.emqutiti/config.toml` and lets you choose which broker to connect to at runtime.
+GoEmqutiti is a terminal based MQTT client built with [Bubble Tea](https://github.com/charmbracelet/bubbletea). It loads broker profiles from `~/.emqutiti/config.toml` and lets you choose which broker to connect to at runtime.
 
 ## Installation
 
@@ -21,13 +21,13 @@ This will produce a `goemqutiti` binary in the current directory.
 
 ## Usage
 
-Run the built binary (or use `go run .`) to start the TUI application. On startup the connection manager is shown so you can select which profile to use. The manager can also be opened at any time with the `m` key. Profiles expose all common connection options inspired by the EMQX MQTT client:
+Run the built binary (or use `go run .`) to start the TUI application. On startup the broker manager is shown so you can select which profile to use. The manager can also be opened at any time with the `Ctrl+B`. Profiles expose all common connection options inspired by the EMQX MQTT client:
 
 ```bash
 ./goemqutiti
 ```
 
-The client expects a configuration file at `~/.emqutiti/config.toml` describing connection profiles. A minimal configuration looks like:
+The client expects a configuration file at `~/.emqutiti/config.toml` describing broker profiles. A minimal configuration looks like:
 
 ```toml
 default_profile = "local"
@@ -48,7 +48,7 @@ In the interface:
 - **Enter** subscribes to a topic when the topic field is focused.
 - **Ctrl+S** publishes the message currently in the editor.
 - **Ctrl+Enter** also publishes the current message.
-- **Ctrl+M** opens the connection manager where you can add, edit or delete MQTT profiles.
+- **Ctrl+B** opens the broker manager where you can add, edit or delete MQTT profiles.
 - **Ctrl+T** manages subscribed topics.
 - **Ctrl+P** manages stored payloads.
 - **Ctrl+C** copies the currently selected history entry.

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This document tracks the tasks and goals for developing the GoEmqutiti MQTT clie
 ## **1. Responsive Layout**
 - [ ] Modularize UI components into separate files:
   - [ ] `header.go` (Header section: title, connection status)
-  - [ ] `connections.go` (Connection manager: list, CRUD operations)
+  - [ ] `connections.go` (Broker manager: list, CRUD operations)
   - [ ] `topic.go` (Topic input section)
   - [ ] `message.go` (Message input section)
   - [ ] `messages_log.go` (Messages log section)
@@ -29,18 +29,18 @@ This document tracks the tasks and goals for developing the GoEmqutiti MQTT clie
 - [ ] Handle cases where the keyring is unavailable or inaccessible.
 
 ### **CRUD Operations**
-- [x] Add new connections with full MQTT configuration options.
-- [x] Edit existing connections.
-- [x] Delete connections.
-- [x] Load connections from the configuration file and keyring on startup.
-- [x] Save connections to the configuration file and keyring when modified.
+- [x] Add new brokers with full MQTT configuration options.
+- [x] Edit existing brokers.
+- [x] Delete brokers.
+- [x] Load brokers from the configuration file and keyring on startup.
+- [x] Save brokers to the configuration file and keyring when modified.
 
 ### **UI Components**
-- [x] Display a selectable list of connections using `bubbles/list`.
-- [x] Provide a menu option to open the connection manager.
+- [x] Display a selectable list of brokers using `bubbles/list`.
+- [x] Provide a menu option to open the broker manager.
 - [ ] Highlight the active connection in the list.
 - [ ] Show connection status (connected/disconnected).
-- [x] Provide a form for adding/editing connections using `bubbles/textinput`.
+- [x] Provide a form for adding/editing brokers using `bubbles/textinput`.
 - [x] Support advanced connection options (keep alive, clean session, TLS, LWT, etc.).
 
 ---

--- a/connections.go
+++ b/connections.go
@@ -43,19 +43,19 @@ type Profile struct {
 	LastWillPayload     string `toml:"last_will_payload"`
 }
 
-// Connections manages the state and logic for handling connections.
+// Connections manages the state and logic for handling broker profiles.
 type Connections struct {
 	ConnectionsList    list.Model
 	TextInput          textinput.Model
 	DefaultProfileName string    `toml:"default_profile"`
 	Profiles           []Profile `toml:"profiles"`
-	Focused            bool      // Indicates if the connection manager is focused
+	Focused            bool      // Indicates if the broker manager is focused
 }
 
 // NewConnectionsModel initializes a new ConnectionsModel with default values.
 func NewConnectionsModel() Connections {
 	connectionList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
-	connectionList.Title = "Connections"
+	connectionList.Title = "Brokers"
 	// Ensure items are visible by setting a reasonable default size
 	connectionList.SetSize(30, 10)
 	connectionList.DisableQuitKeybindings()

--- a/update.go
+++ b/update.go
@@ -178,7 +178,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 			}
 		default:
 			switch msg.String() {
-			case "ctrl+m":
+			case "ctrl+b":
 				m.connections.LoadProfiles("")
 				items := []list.Item{}
 				for _, p := range m.connections.Profiles {
@@ -324,7 +324,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			i := m.connections.ConnectionsList.Index()
 			if i >= 0 {
 				name := m.connections.Profiles[i].Name
-				m.startConfirm(fmt.Sprintf("Delete connection '%s'? [y/n]", name), func() {
+				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), func() {
 					m.connections.DeleteConnection(i)
 					items := []list.Item{}
 					for _, p := range m.connections.Profiles {

--- a/views.go
+++ b/views.go
@@ -28,7 +28,7 @@ func wrapChips(chips []string, width int) string {
 }
 
 func (m *model) viewClient() string {
-	infoLine := infoStyle.Render("Info: Press Ctrl+M for connections, Ctrl+T topics, Ctrl+P payloads. " + m.connection)
+	infoLine := infoStyle.Render("Info: Press Ctrl+B for brokers, Ctrl+T topics, Ctrl+P payloads. " + m.connection)
 
 	var chips []string
 	for i, t := range m.topics {


### PR DESCRIPTION
## Summary
- rename connection manager to broker manager in docs and code
- change global shortcut from `Ctrl+M` to `Ctrl+B`
- adjust README, TODO, and AGENTS docs

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884bb20c93c83249d221d5b37086192