### PR TITLE
Add random client ID suffix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,43 @@ Run the built binary (or use `go run .`) to start the TUI application. On startu
 ./goemqutiti
 ```
 
-The client expects a configuration file at `~/.emqutiti/config.toml` describing broker profiles. A minimal configuration looks like:
+The client expects a configuration file at `~/.emqutiti/config.toml` describing broker profiles. A sample configuration with all options looks like:
 
 ```toml
 default_profile = "local"
 
 [[profiles]]
 name = "local"
-broker = "tcp://localhost:1883"
+schema = "tcp"
+host = "localhost"
+port = 1883
 client_id = "goemqutiti"
+random_id_suffix = false       # append nano timestamp to the client ID
 username = "user"
 password = "keyring:emqutiti-local/user"
+ssl_tls = false                # enable TLS/SSL encryption
+mqtt_version = ""              # protocol version 3, 4, or 5
+connect_timeout = 0            # seconds to wait when connecting
+keep_alive = 0                 # keep-alive interval in seconds
+qos = 0                        # default Quality of Service level
+auto_reconnect = false         # automatically reconnect when the link drops
+reconnect_period = 0           # seconds between reconnect attempts
+clean_start = false            # start a clean session (MQTT v5)
+session_expiry_interval = 0    # session expiry time in seconds
+receive_maximum = 0            # maximum inflight messages
+maximum_packet_size = 0        # limit the packet size in bytes
+topic_alias_maximum = 0        # maximum number of topic aliases
+request_response_info = false  # request response information from the broker
+request_problem_info = false   # request problem information from the broker
+last_will_enabled = false      # enable a Last Will and Testament message
+last_will_topic = ""
+last_will_qos = 0
+last_will_retain = false
+last_will_payload = ""
 ```
+
+Setting `random_id_suffix` to `true` appends a nano timestamp to the client ID
+so multiple connections remain unique.
 
 Passwords can be stored securely using the operating system keyring. You may also set the `MQTT_PASSWORD` environment variable to override the stored password at runtime.
 
@@ -69,4 +94,4 @@ Unit tests can be run with `go test ./...`. The example `ExampleSet_manual` in
 `keyring_util_test.go` interacts with the real system keyring and is excluded
 from automated runs. Execute it manually when a keyring is available.
 
-Additional notes for repository contributors are available in [Agent.md](Agent.md).
+Additional notes for repository contributors are available in [AGENTS.md](AGENTS.md).

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ This document tracks the tasks and goals for developing the GoEmqutiti MQTT clie
 ### **Secure Storage**
 - [x] Integrate Linux keyring using [`zalando/go-keyring`](https://github.com/zalando/go-keyring).
 - [x] Store sensitive fields (e.g., passwords) in the keyring.
-- [ ] Update `config.toml` to reference keyring entries (e.g., `password = "keyring:<service>/<username>"`).
+ - [x] Update `config.toml` to reference keyring entries (e.g., `password = "keyring:<service>/<username>"`).
 - [ ] Prompt user to unlock the keyring on application startup.
 - [ ] Handle cases where the keyring is unavailable or inaccessible.
 
@@ -42,11 +42,12 @@ This document tracks the tasks and goals for developing the GoEmqutiti MQTT clie
 - [ ] Show connection status (connected/disconnected).
 - [x] Provide a form for adding/editing brokers using `bubbles/textinput`.
 - [x] Support advanced connection options (keep alive, clean session, TLS, LWT, etc.).
+- [x] Option to append a random client ID suffix.
 
 ---
 
 ## **3. General Features**
- - [ ] Implement keyboard shortcuts for navigation and actions. (Ctrl+S or Ctrl+Enter to publish messages)
+ - [x] Implement keyboard shortcuts for navigation and actions. (Ctrl+S or Ctrl+Enter to publish messages)
 - [ ] Add error handling for failed connections or invalid inputs.
 - [ ] Persist all data securely between application runs.
 - [ ] Support dynamic updates from the MQTT broker (real-time message logging).

--- a/connectionform.go
+++ b/connectionform.go
@@ -140,6 +140,7 @@ const (
 	idxHost
 	idxPort
 	idxClientID
+	idxIDSuffix
 	idxUsername
 	idxPassword
 	idxSSL
@@ -174,6 +175,7 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 		p.Host,
 		fmt.Sprintf("%d", p.Port),
 		p.ClientID,
+		"", // checkbox for rand suffix
 		p.Username,
 		"",
 		"", // placeholder for checkbox
@@ -203,6 +205,7 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 		"Host",
 		"Port",
 		"Client ID",
+		"Random ID suffix",
 		"Username",
 		pwKey,
 		"SSL/TLS",
@@ -235,6 +238,7 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 		idxRequestProb:   true,
 		idxWillEnable:    true,
 		idxWillRetain:    true,
+		idxIDSuffix:      true,
 	}
 
 	selectOptions := map[int][]string{
@@ -245,6 +249,7 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 	}
 
 	boolValues := []bool{
+		p.RandomIDSuffix,
 		p.SSL,
 		p.AutoReconnect,
 		p.CleanStart,
@@ -329,6 +334,7 @@ func (f connectionForm) View() string {
 		"Host",
 		"Port",
 		"Client ID",
+		"Random ID suffix",
 		"Username",
 		"Password",
 		"SSL/TLS",
@@ -394,5 +400,6 @@ func (f connectionForm) Profile() Profile {
 	fmt.Sscan(vals[idxWillQos], &p.LastWillQos)
 	fmt.Sscan(vals[idxWillRetain], &p.LastWillRetain)
 	p.LastWillPayload = vals[idxWillPayload]
+	fmt.Sscan(vals[idxIDSuffix], &p.RandomIDSuffix)
 	return p
 }

--- a/connections.go
+++ b/connections.go
@@ -41,6 +41,7 @@ type Profile struct {
 	LastWillQos         int    `toml:"last_will_qos"`
 	LastWillRetain      bool   `toml:"last_will_retain"`
 	LastWillPayload     string `toml:"last_will_payload"`
+	RandomIDSuffix      bool   `toml:"random_id_suffix"`
 }
 
 // Connections manages the state and logic for handling broker profiles.

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -18,7 +18,11 @@ func NewMQTTClient(p Profile, statusChan chan string) (*MQTTClient, error) {
 	opts := mqtt.NewClientOptions()
 	brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
 	opts.AddBroker(brokerURL)
-	opts.SetClientID(p.ClientID)
+	cid := p.ClientID
+	if p.RandomIDSuffix {
+		cid = fmt.Sprintf("%s-%d", cid, time.Now().UnixNano())
+	}
+	opts.SetClientID(cid)
 	opts.SetUsername(p.Username)
 
 	if len(p.Password) > 0 {


### PR DESCRIPTION
## Summary
- add `RandomIDSuffix` flag to broker profiles
- append nano timestamp to ClientID when flag enabled
- expose checkbox "Random ID suffix" in connection form (just below Client ID)
- document new setting in README
- list other available profile options
- mark relevant TODO items as done
- integrate optional settings directly into the config example

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884bf40fd2483249d32acca00d7e295