### PR TITLE
UI enhancements and multi-select history

### DIFF
--- a/historydelegate.go
+++ b/historydelegate.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// historyDelegate renders history items with two lines and supports highlighting
+// selected entries.
+type historyDelegate struct{ m *model }
+
+func (d historyDelegate) Height() int                               { return 2 }
+func (d historyDelegate) Spacing() int                              { return 0 }
+func (d historyDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
+
+func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	hi := item.(historyItem)
+	width := m.Width()
+	var label string
+	var lblColor lipgloss.Color
+	var msgColor lipgloss.Color
+	switch hi.kind {
+	case "sub":
+		label = fmt.Sprintf("SUB %s:", hi.topic)
+		lblColor = lipgloss.Color("205")
+		msgColor = lipgloss.Color("219")
+	case "pub":
+		label = fmt.Sprintf("PUB %s:", hi.topic)
+		lblColor = lipgloss.Color("63")
+		msgColor = lipgloss.Color("81")
+	default:
+		fmt.Fprint(w, lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Width(width).Render(hi.payload))
+		return
+	}
+	align := lipgloss.Left
+	if hi.kind == "pub" {
+		align = lipgloss.Right
+	}
+	line1 := lipgloss.PlaceHorizontal(width, align, lipgloss.NewStyle().Foreground(lblColor).Render(label))
+	line2 := lipgloss.NewStyle().Foreground(msgColor).Width(width).Render(hi.payload)
+	lines := []string{line1, line2}
+	if _, ok := d.m.selectedHistory[index]; ok {
+		for i, l := range lines {
+			lines[i] = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(l)
+		}
+	}
+	fmt.Fprint(w, strings.Join(lines, "\n"))
+}

--- a/styles.go
+++ b/styles.go
@@ -39,12 +39,20 @@ func legendStyledBox(content, label string, width int, color lipgloss.Color) str
 		width = lipgloss.Width(label) + 4
 	}
 	b := lipgloss.RoundedBorder()
-	top := b.TopLeft + " " + label + " " + strings.Repeat(b.Top, width-lipgloss.Width(label)-4) + b.TopRight
-	bottom := b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight
+	cy := lipgloss.Color("51")
+	top := lipgloss.NewStyle().Foreground(color).Render(b.TopLeft+" "+label+" "+strings.Repeat(b.Top, width-lipgloss.Width(label)-4)) +
+		lipgloss.NewStyle().Foreground(cy).Render(b.TopRight)
+	bottom := lipgloss.NewStyle().Foreground(cy).Render(b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight)
 	lines := strings.Split(content, "\n")
 	for i, l := range lines {
-		lines[i] = b.Left + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l) + b.Right
+		side := color
+		if i == len(lines)-1 {
+			side = cy
+		}
+		left := lipgloss.NewStyle().Foreground(color).Render(b.Left)
+		right := lipgloss.NewStyle().Foreground(side).Render(b.Right)
+		lines[i] = left + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l) + right
 	}
 	middle := strings.Join(lines, "\n")
-	return lipgloss.NewStyle().Foreground(color).Render(top + "\n" + middle + "\n" + bottom)
+	return top + "\n" + middle + "\n" + bottom
 }

--- a/views.go
+++ b/views.go
@@ -44,12 +44,12 @@ func (m *model) viewClient() string {
 	topicsFocused := m.focusOrder[m.focusIndex] == "topics"
 	historyFocused := m.focusOrder[m.focusIndex] == "history"
 
-	topicsBox := legendBox(wrapChips(chips, m.width-6), "Topics", m.width-4, topicsFocused)
+	topicsBox := legendBox(wrapChips(chips, m.width-4), "Topics", m.width-2, topicsFocused)
 
-	messagesBox := legendGreenBox(m.history.View(), "History (Ctrl+C copy)", m.width-4, historyFocused)
+	messagesBox := legendGreenBox(m.history.View(), "History (Ctrl+C copy)", m.width-2, historyFocused)
 
-	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-4, m.focusIndex == 0)
-	messageBox := legendBox(m.messageInput.View(), "Message", m.width-4, m.focusIndex == 1)
+	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-2, m.focusIndex == 0)
+	messageBox := legendBox(m.messageInput.View(), "Message", m.width-2, m.focusIndex == 1)
 
 	inputsBox := lipgloss.JoinVertical(lipgloss.Left, topicBox, messageBox)
 


### PR DESCRIPTION
## Summary
- improve layout widths and border gradients
- make history view multi-selectable with keyboard
- new delegate for history items with two-line formatting
- keep narrower History box title
- adjust inputs and layout sizing

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884ee1f2a0c8324b0511f18397c2bb4