### PR TITLE
UI tweaks and delete-topic regression test

### DIFF
--- a/historydelegate.go
+++ b/historydelegate.go
@@ -49,5 +49,15 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 			lines[i] = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(l)
 		}
 	}
+	border := " "
+	if _, ok := d.m.selectedHistory[index]; ok {
+		border = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Render("┃")
+	}
+	if index == d.m.history.Index() {
+		border = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Render("┃")
+	}
+	for i, l := range lines {
+		lines[i] = border + " " + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l)
+	}
 	fmt.Fprint(w, strings.Join(lines, "\n"))
 }

--- a/model.go
+++ b/model.go
@@ -138,8 +138,11 @@ func initialModel(conns *Connections) *model {
 	ta.CharLimit = 10000
 	ta.ShowLineNumbers = false
 	ta.SetPromptFunc(0, func(i int) string {
-		return fmt.Sprintf(">%d ", i+1)
+		return fmt.Sprintf("%d> ", i+1)
 	})
+	promptColor := lipgloss.Color("240")
+	ta.FocusedStyle.Prompt = lipgloss.NewStyle().Foreground(promptColor)
+	ta.BlurredStyle.Prompt = lipgloss.NewStyle().Foreground(promptColor)
 	ta.Blur()
 	ta.Cursor.Style = noCursor
 	// Set width once the WindowSizeMsg arrives

--- a/styles.go
+++ b/styles.go
@@ -13,7 +13,7 @@ var (
 	noCursor     = lipgloss.NewStyle()
 	borderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1)
 	greenBorder  = borderStyle.BorderForeground(lipgloss.Color("34"))
-	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
+	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true).Inline(true)
 	chipInactive = chipStyle.Foreground(lipgloss.Color("240"))
 	infoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).PaddingLeft(1)
 )

--- a/topic_delete_test.go
+++ b/topic_delete_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that deleting a topic via confirmation removes it from the list
+func TestDeleteTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.topics = []topicItem{{title: "a", active: true}, {title: "b", active: false}}
+	m.setFocus("topics")
+	m.selectedTopic = 0
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd == nil || m.mode != modeConfirmDelete {
+		t.Fatalf("expected confirm delete mode")
+	}
+	if m.confirmAction == nil {
+		t.Fatalf("confirm action not set")
+	}
+	if len(m.topics) != 2 {
+		t.Fatalf("unexpected topics before confirm: %#v", m.topics)
+	}
+	t.Logf("before confirm: %#v", m.topics)
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	t.Logf("after confirm: %#v", m.topics)
+	if len(m.topics) != 1 || m.topics[0].title != "b" {
+		t.Fatalf("topic not removed: %#v", m.topics)
+	}
+}

--- a/update.go
+++ b/update.go
@@ -455,7 +455,7 @@ func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
 	return m, tea.Batch(cmd, listenStatus(m.statusChan))
 }
 
-func (m model) updateConfirmDelete(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateConfirmDelete(msg tea.Msg) (model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -469,7 +469,7 @@ func (m model) updateConfirmDelete(msg tea.Msg) (model, tea.Cmd) {
 			m.mode = m.prevMode
 		}
 	}
-	return m, listenStatus(m.statusChan)
+	return *m, listenStatus(m.statusChan)
 }
 
 func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {


### PR DESCRIPTION
## Summary
- fix confirm delete logic overwriting slice
- show clear selection bars in history
- adjust message line number styling
- refine chip rendering
- add regression test for topic deletion

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6884fc82242c8324baa7877226b415c6