### PR TITLE
Fix topic chip borders

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -13,7 +13,7 @@ var (
 	noCursor     = lipgloss.NewStyle()
 	borderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1)
 	greenBorder  = borderStyle.BorderForeground(lipgloss.Color("34"))
-	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true).Inline(true)
+	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
 	chipInactive = chipStyle.Foreground(lipgloss.Color("240"))
 	infoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).PaddingLeft(1)
 )

--- a/views.go
+++ b/views.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -13,7 +14,9 @@ func wrapChips(chips []string, width int) string {
 	for _, c := range chips {
 		cw := lipgloss.Width(c)
 		if cur+cw > width && len(row) > 0 {
-			lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, row...))
+			line := lipgloss.JoinHorizontal(lipgloss.Top, row...)
+			line = strings.TrimRightFunc(line, unicode.IsSpace)
+			lines = append(lines, line)
 			row = []string{c}
 			cur = cw
 		} else {
@@ -22,7 +25,9 @@ func wrapChips(chips []string, width int) string {
 		}
 	}
 	if len(row) > 0 {
-		lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, row...))
+		line := lipgloss.JoinHorizontal(lipgloss.Top, row...)
+		line = strings.TrimRightFunc(line, unicode.IsSpace)
+		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary
- restore borders around topic chips by removing `Inline(true)` from chip style
- trim spaces in each row of chips so the Topics box retains its right border

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68850bef2f088324b77b08bff874b861