### PR TITLE
Fix extra blank lines in topic chips

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -35,6 +35,7 @@ func legendGreenBox(content, label string, width int, focused bool) string {
 }
 
 func legendStyledBox(content, label string, width int, color lipgloss.Color) string {
+	content = strings.TrimRight(content, "\n")
 	if width < lipgloss.Width(label)+4 {
 		width = lipgloss.Width(label) + 4
 	}


### PR DESCRIPTION
## Summary
- trim trailing newlines before rendering a `legendStyledBox`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885151f6a4883248818b7ba00aa2793