### PR TITLE
Fix message publish and topic subscribe shortcuts

### DIFF
--- a/focus_test.go
+++ b/focus_test.go
@@ -16,8 +16,8 @@ func TestSetFocusMessage(t *testing.T) {
 	if !m.messageInput.Focused() {
 		t.Fatalf("message input not focused after setFocus")
 	}
-	if m.focusIndex != 1 {
-		t.Fatalf("focusIndex expected 1, got %d", m.focusIndex)
+	if m.focusIndex != 2 {
+		t.Fatalf("focusIndex expected 2, got %d", m.focusIndex)
 	}
 	if cmd == nil {
 		t.Fatalf("expected non-nil command from setFocus")
@@ -25,15 +25,16 @@ func TestSetFocusMessage(t *testing.T) {
 }
 
 // Test that pressing Tab cycles focus from topic to message
-func TestTabCyclesToMessage(t *testing.T) {
+// Test that pressing Tab cycles focus from topics to topic input
+func TestTabCyclesToTopic(t *testing.T) {
 	m := initialModel(nil)
 	if m.focusIndex != 0 {
 		t.Fatalf("initial focus index should be 0")
 	}
 	msg := tea.KeyMsg{Type: tea.KeyTab}
 	_, cmd := m.Update(msg)
-	if !m.messageInput.Focused() {
-		t.Fatalf("message input should be focused after tab")
+	if !m.topicInput.Focused() {
+		t.Fatalf("topic input should be focused after tab")
 	}
 	if m.focusIndex != 1 {
 		t.Fatalf("focus index should be 1 after tab, got %d", m.focusIndex)

--- a/topic_publish_test.go
+++ b/topic_publish_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that pressing enter in the topic input subscribes to that topic
+func TestEnterAddsTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.topicInput.SetValue("foo")
+	m.setFocus("topic")
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected command on enter")
+	}
+	if len(m.topics) != 1 || m.topics[0].title != "foo" || !m.topics[0].active {
+		t.Fatalf("topic not added: %#v", m.topics)
+	}
+}
+
+// Test that ctrl+s publishes the message in the editor
+func TestCtrlSPublishesMessage(t *testing.T) {
+	m := initialModel(nil)
+	m.topics = []topicItem{{title: "foo", active: true}}
+	m.messageInput.SetValue("hello")
+	m.setFocus("message")
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatalf("expected command on ctrl+s")
+	}
+	if len(m.payloads) != 1 || m.payloads[0].payload != "hello" {
+		t.Fatalf("payload not stored: %#v", m.payloads)
+	}
+	if len(m.history.Items()) != 1 {
+		t.Fatalf("history entry not added")
+	}
+}

--- a/update.go
+++ b/update.go
@@ -220,7 +220,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 				m.selectionAnchor = -1
 			}
 		case "ctrl+s", "ctrl+enter":
-			if m.focusIndex == 1 {
+			if m.focusOrder[m.focusIndex] == "message" {
 				payload := m.messageInput.Value()
 				for _, t := range m.topics {
 					if t.active {
@@ -233,7 +233,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 				}
 			}
 		case "enter":
-			if m.focusIndex == 0 {
+			if m.focusOrder[m.focusIndex] == "topic" {
 				topic := strings.TrimSpace(m.topicInput.Value())
 				if topic != "" && !m.hasTopic(topic) {
 					m.topics = append(m.topics, topicItem{title: topic, active: true})

--- a/views.go
+++ b/views.go
@@ -33,7 +33,7 @@ func wrapChips(chips []string, width int) string {
 }
 
 func (m *model) viewClient() string {
-	infoLine := infoStyle.Render("Info: Press Ctrl+B for brokers, Ctrl+T topics, Ctrl+P payloads. " + m.connection)
+	infoLine := infoStyle.Render("Info: Enter subscribes, Ctrl+S publishes, Ctrl+B brokers, Ctrl+T topics, Ctrl+P payloads. " + m.connection)
 
 	var chips []string
 	for i, t := range m.topics {


### PR DESCRIPTION
## Summary
- fix focus checks for publishing and subscribing actions
- display info about Enter and Ctrl+S in the client view
- update focus tests for the current focus order
- add regression tests for publishing and subscribing

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885254d3bd48324a58ddfef2d0f71f7