### PR TITLE
Fix history alignment and add regression tests

### DIFF
--- a/history_view_test.go
+++ b/history_view_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Test that historyDelegate renders lines that fit the list width
+func TestHistoryDelegateWidth(t *testing.T) {
+	m := initialModel(nil)
+	d := historyDelegate{m: m}
+	m.history.SetSize(30, 4)
+	hi := historyItem{topic: "foo", payload: "bar", kind: "pub"}
+	var buf bytes.Buffer
+	d.Render(&buf, m.history, 0, hi)
+	lines := strings.Split(buf.String(), "\n")
+	for i, line := range lines {
+		if lipgloss.Width(line) != 30 {
+			t.Fatalf("line %d width=%d want=30", i, lipgloss.Width(line))
+		}
+	}
+}
+
+// Test that the history box has aligned borders when rendered
+func TestHistoryBoxLayout(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	m.appendHistory("foo", "bar", "pub", "")
+	view := m.viewClient()
+	lines := strings.Split(view, "\n")
+	var hist []string
+	collecting := false
+	for _, l := range lines {
+		if strings.Contains(l, "History") {
+			collecting = true
+		}
+		if collecting {
+			hist = append(hist, l)
+			if strings.Contains(l, "\u2518") { // bottom right corner '┘'
+				break
+			}
+		}
+	}
+	if len(hist) == 0 {
+		t.Fatalf("history box not found in view")
+	}
+	width := lipgloss.Width(hist[0])
+	for i, l := range hist {
+		if lipgloss.Width(l) != width {
+			t.Fatalf("history line %d width=%d want=%d", i, lipgloss.Width(l), width)
+		}
+	}
+}

--- a/historydelegate.go
+++ b/historydelegate.go
@@ -41,8 +41,12 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	if hi.kind == "pub" {
 		align = lipgloss.Right
 	}
-	line1 := lipgloss.PlaceHorizontal(width, align, lipgloss.NewStyle().Foreground(lblColor).Render(label))
-	line2 := lipgloss.PlaceHorizontal(width, align, lipgloss.NewStyle().Foreground(msgColor).Render(hi.payload))
+	innerWidth := width - 2
+	if innerWidth < 0 {
+		innerWidth = 0
+	}
+	line1 := lipgloss.PlaceHorizontal(innerWidth, align, lipgloss.NewStyle().Foreground(lblColor).Render(label))
+	line2 := lipgloss.PlaceHorizontal(innerWidth, align, lipgloss.NewStyle().Foreground(msgColor).Render(hi.payload))
 	lines := []string{line1, line2}
 	if _, ok := d.m.selectedHistory[index]; ok {
 		for i, l := range lines {


### PR DESCRIPTION
## Summary
- fix width calculation in `historyDelegate.Render`
- add tests for history rendering width and legend box layout

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688527988a1c832491beaef1985f568d