### PR TITLE
Improve history view layout

### DIFF
--- a/historydelegate.go
+++ b/historydelegate.go
@@ -45,12 +45,20 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	if innerWidth < 0 {
 		innerWidth = 0
 	}
-	line1 := lipgloss.PlaceHorizontal(innerWidth, align, lipgloss.NewStyle().Foreground(lblColor).Render(label))
-	line2 := lipgloss.PlaceHorizontal(innerWidth, align, lipgloss.NewStyle().Foreground(msgColor).Render(hi.payload))
-	lines := []string{line1, line2}
+	line1 := lipgloss.PlaceHorizontal(innerWidth, align,
+		lipgloss.NewStyle().Foreground(lblColor).Render(label))
+
+	// Support multi-line payloads by aligning each line individually
+	var lines []string
+	lines = append(lines, line1)
+	for _, l := range strings.Split(hi.payload, "\n") {
+		rendered := lipgloss.PlaceHorizontal(innerWidth, align,
+			lipgloss.NewStyle().Foreground(msgColor).Render(l))
+		lines = append(lines, rendered)
+	}
 	if _, ok := d.m.selectedHistory[index]; ok {
 		for i, l := range lines {
-			lines[i] = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(l)
+			lines[i] = lipgloss.NewStyle().Background(lipgloss.Color("237")).Render(l)
 		}
 	}
 	border := " "

--- a/styles.go
+++ b/styles.go
@@ -35,15 +35,26 @@ func legendGreenBox(content, label string, width int, focused bool) string {
 }
 
 func legendStyledBox(content, label string, width int, color lipgloss.Color) string {
-	content = strings.Trim(content, "\n")
+	content = strings.TrimRight(content, "\n")
 	if width < lipgloss.Width(label)+4 {
 		width = lipgloss.Width(label) + 4
 	}
+	// Ensure the box is wide enough for the content
+	for _, l := range strings.Split(content, "\n") {
+		if w := lipgloss.Width(l) + 2; w > width {
+			width = w
+		}
+	}
+
 	b := lipgloss.RoundedBorder()
 	cy := lipgloss.Color("51")
-	top := lipgloss.NewStyle().Foreground(color).Render(b.TopLeft+" "+label+" "+strings.Repeat(b.Top, width-lipgloss.Width(label)-4)) +
-		lipgloss.NewStyle().Foreground(cy).Render(b.TopRight)
-	bottom := lipgloss.NewStyle().Foreground(cy).Render(b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight)
+	top := lipgloss.NewStyle().Foreground(color).Render(
+		b.TopLeft+" "+label+" "+strings.Repeat(b.Top, width-lipgloss.Width(label)-4),
+	) + lipgloss.NewStyle().Foreground(cy).Render(b.TopRight)
+	bottom := lipgloss.NewStyle().Foreground(cy).Render(
+		b.BottomLeft + strings.Repeat(b.Bottom, width-2) + b.BottomRight,
+	)
+
 	lines := strings.Split(content, "\n")
 	for i, l := range lines {
 		side := color


### PR DESCRIPTION
## Summary
- align multi-line payloads in history items
- use a lighter background for selected history lines
- ensure legend box width accounts for content

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68852b76b80c8324b0d66727fea7e7ee