### PR TITLE
Fix mouse topic selection logic

### DIFF
--- a/topic_mouse_test.go
+++ b/topic_mouse_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func chipCoords(m *model, idx int) (int, int) {
+	width := m.width - 4
+	curX, curY := 0, 0
+	for i, t := range m.topics {
+		chip := chipStyle.Render(t.title)
+		if !t.active {
+			chip = chipInactive.Render(t.title)
+		}
+		w := lipgloss.Width(chip)
+		if curX+w > width && curX > 0 {
+			curY++
+			curX = 0
+		}
+		if i == idx {
+			return curX, curY
+		}
+		curX += w
+	}
+	return -1, -1
+}
+
+func setupTopics(m *model) {
+	names := []string{"testtopic", "asdfsedf", "asdasd", "sdfdfasssssd", "asdasdasss", "asasasdfffa", "asasdfa", "aasdf", "asdfa", "asdasasdfasdf"}
+	for _, n := range names {
+		m.topics = append(m.topics, topicItem{title: n, active: true})
+	}
+}
+
+func TestMouseToggleFirstTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	setupTopics(m)
+	m.viewClient()
+	x, y := chipCoords(m, 0)
+	start := m.elemPos["topics"] + 1
+	_, _ = m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start})
+	if m.selectedTopic != 0 {
+		t.Fatalf("expected selected topic 0, got %d", m.selectedTopic)
+	}
+	if m.topics[0].active {
+		t.Fatalf("topic 0 not toggled")
+	}
+}
+
+func TestMouseToggleThirdRowTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	setupTopics(m)
+	m.viewClient()
+	// topic index 6 resides on third row
+	x, y := chipCoords(m, 6)
+	start := m.elemPos["topics"] + 1
+	_, _ = m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start})
+	if m.selectedTopic != 6 {
+		t.Fatalf("expected selected topic 6, got %d", m.selectedTopic)
+	}
+	if m.topics[6].active {
+		t.Fatalf("topic 6 not toggled")
+	}
+}

--- a/update.go
+++ b/update.go
@@ -319,7 +319,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		}
 		if m.focusOrder[m.focusIndex] == "topics" {
 			start := m.elemPos["topics"] + 1
-			idx := m.topicAtPosition(msg.X-2, msg.Y-start, m.width-6)
+			idx := m.topicAtPosition(msg.X-2, msg.Y-start, m.width-4)
 			if idx >= 0 {
 				m.selectedTopic = idx
 				if msg.Type == tea.MouseLeft {


### PR DESCRIPTION
## Summary
- correct topic selection width calculation
- add regression tests for mouse selection of topics

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68853a77f0508324996d1da47e085eeb