### PR TITLE
Fix mouse topic selection logic

### DIFF
--- a/model.go
+++ b/model.go
@@ -262,7 +262,15 @@ func (m *model) removeTopic(index int) {
 }
 
 func (m *model) topicAtPosition(x, y, width int) int {
-	curX, curY := 0, 0
+	// Chips render with a height of three lines. When wrapped to the next
+	// row there is no extra blank line inserted, so rows are spaced by the
+	// chip height alone. Map the mouse coordinates into this grid to locate
+	// the clicked chip.
+	chipH := lipgloss.Height(chipStyle.Render("test"))
+	rowSpacing := chipH
+
+	curX := 0
+	rowTop := 0
 	for i, t := range m.topics {
 		chip := chipStyle.Render(t.title)
 		if !t.active {
@@ -270,10 +278,10 @@ func (m *model) topicAtPosition(x, y, width int) int {
 		}
 		w := lipgloss.Width(chip)
 		if curX+w > width && curX > 0 {
-			curY++
+			rowTop += rowSpacing
 			curX = 0
 		}
-		if y == curY && x >= curX && x < curX+w {
+		if y >= rowTop && y < rowTop+chipH && x >= curX && x < curX+w {
 			return i
 		}
 		curX += w

--- a/topic_mouse_test.go
+++ b/topic_mouse_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func chipCoords(m *model, idx int) (int, int) {
+	width := m.width - 4
+	chipH := lipgloss.Height(chipStyle.Render("test"))
+	rowSpacing := chipH
+
+	curX := 0
+	rowTop := 0
+	for i, t := range m.topics {
+		chip := chipStyle.Render(t.title)
+		if !t.active {
+			chip = chipInactive.Render(t.title)
+		}
+		w := lipgloss.Width(chip)
+		if curX+w > width && curX > 0 {
+			rowTop += rowSpacing
+			curX = 0
+		}
+		if i == idx {
+			return curX, rowTop
+		}
+		curX += w
+	}
+	return -1, -1
+}
+
+func setupTopics(m *model) {
+	names := []string{"testtopic", "asdfsedf", "asdasd", "sdfdfasssssd", "asdasdasss", "asasasdfffa", "asasdfa", "aasdf", "asdfa", "asdasasdfasdf"}
+	for _, n := range names {
+		m.topics = append(m.topics, topicItem{title: n, active: true})
+	}
+}
+
+func TestMouseToggleFirstTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	setupTopics(m)
+	m.viewClient()
+	x, y := chipCoords(m, 0)
+	start := m.elemPos["topics"] + 1
+	for offset := 0; offset < 3; offset++ {
+		activeBefore := m.topics[0].active
+		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		if m.selectedTopic != 0 {
+			t.Fatalf("expected selected topic 0, got %d", m.selectedTopic)
+		}
+		if m.topics[0].active == activeBefore {
+			t.Fatalf("click offset %d did not toggle topic", offset)
+		}
+	}
+}
+
+func TestMouseToggleThirdRowTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	setupTopics(m)
+	m.viewClient()
+	// topic index 6 resides on third row
+	x, y := chipCoords(m, 6)
+	start := m.elemPos["topics"] + 1
+	for offset := 0; offset < 3; offset++ {
+		before := m.topics[6].active
+		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		if m.selectedTopic != 6 {
+			t.Fatalf("expected selected topic 6, got %d", m.selectedTopic)
+		}
+		if m.topics[6].active == before {
+			t.Fatalf("offset %d did not toggle topic 6", offset)
+		}
+	}
+}
+
+func TestMouseToggleFourthRowTopic(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	setupTopics(m)
+	m.viewClient()
+	// topic index 8 resides on the fourth row
+	x, y := chipCoords(m, 8)
+	start := m.elemPos["topics"] + 1
+	for offset := 0; offset < 3; offset++ {
+		before := m.topics[8].active
+		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		if m.selectedTopic != 8 {
+			t.Fatalf("expected selected topic 8, got %d", m.selectedTopic)
+		}
+		if m.topics[8].active == before {
+			t.Fatalf("offset %d did not toggle topic 8", offset)
+		}
+	}
+}

--- a/update.go
+++ b/update.go
@@ -318,19 +318,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 			cmds = append(cmds, m.focusFromMouse(msg.Y))
 		}
 		if m.focusOrder[m.focusIndex] == "topics" {
-			start := m.elemPos["topics"] + 1
-			idx := m.topicAtPosition(msg.X-2, msg.Y-start, m.width-6)
-			if idx >= 0 {
-				m.selectedTopic = idx
-				if msg.Type == tea.MouseLeft {
-					m.toggleTopic(idx)
-				} else if msg.Type == tea.MouseRight {
-					name := m.topics[idx].title
-					m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), func() {
-						m.removeTopic(idx)
-					})
-				}
-			}
+			m.handleTopicsClick(msg)
 		}
 	}
 
@@ -355,6 +343,26 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, listenMessages(m.mqttClient.MessageChan))
 	}
 	return tea.Batch(cmds...)
+}
+
+// handleTopicsClick processes mouse events within the topics area. The
+// coordinates are relative to the entire viewport, so we subtract the info
+// line and box border to get chip positions.
+func (m *model) handleTopicsClick(msg tea.MouseMsg) {
+	start := m.elemPos["topics"] + 1
+	idx := m.topicAtPosition(msg.X-2, msg.Y-start, m.width-4)
+	if idx < 0 {
+		return
+	}
+	m.selectedTopic = idx
+	if msg.Type == tea.MouseLeft {
+		m.toggleTopic(idx)
+	} else if msg.Type == tea.MouseRight {
+		name := m.topics[idx].title
+		m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), func() {
+			m.removeTopic(idx)
+		})
+	}
 }
 
 func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {


### PR DESCRIPTION
## Summary
- compute chip rows using correct spacing so clicks map to the right topic
- extend mouse selection tests to cover a fourth-row chip
- merge latest `main`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68853a77f0508324996d1da47e085eeb