### PR TITLE
Fix deprecated mouse event usage

### DIFF
--- a/connectionform.go
+++ b/connectionform.go
@@ -104,7 +104,7 @@ func (c *checkField) Update(msg tea.Msg) tea.Cmd {
 			c.value = !c.value
 		}
 	case tea.MouseMsg:
-		if m.Type == tea.MouseLeft {
+		if m.Action == tea.MouseActionPress && m.Button == tea.MouseButtonLeft {
 			c.value = !c.value
 		}
 	}
@@ -305,7 +305,7 @@ func (f connectionForm) Update(msg tea.Msg) (connectionForm, tea.Cmd) {
 			}
 		}
 	case tea.MouseMsg:
-		if msg.Type == tea.MouseLeft {
+		if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
 			// crude calculation: rows correspond to field order
 			if msg.Y >= 1 && msg.Y-1 < len(f.fields) {
 				f.focus = msg.Y - 1

--- a/topic_mouse_test.go
+++ b/topic_mouse_test.go
@@ -49,7 +49,7 @@ func TestMouseToggleFirstTopic(t *testing.T) {
 	start := m.elemPos["topics"] + 2
 	for offset := 0; offset < 3; offset++ {
 		activeBefore := m.topics[0].active
-		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x + 2, Y: y + start + offset})
 		if m.selectedTopic != 0 {
 			t.Fatalf("expected selected topic 0, got %d", m.selectedTopic)
 		}
@@ -69,7 +69,7 @@ func TestMouseToggleThirdRowTopic(t *testing.T) {
 	start := m.elemPos["topics"] + 2
 	for offset := 0; offset < 3; offset++ {
 		before := m.topics[6].active
-		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x + 2, Y: y + start + offset})
 		if m.selectedTopic != 6 {
 			t.Fatalf("expected selected topic 6, got %d", m.selectedTopic)
 		}
@@ -89,7 +89,7 @@ func TestMouseToggleFourthRowTopic(t *testing.T) {
 	start := m.elemPos["topics"] + 2
 	for offset := 0; offset < 3; offset++ {
 		before := m.topics[8].active
-		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x + 2, Y: y + start + offset})
 		if m.selectedTopic != 8 {
 			t.Fatalf("expected selected topic 8, got %d", m.selectedTopic)
 		}
@@ -118,7 +118,7 @@ func TestMouseToggleFifteenthRowTopic(t *testing.T) {
 	start := m.elemPos["topics"] + 2
 	for offset := 0; offset < 3; offset++ {
 		before := m.topics[idx].active
-		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x + 2, Y: y + start + offset})
+		m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x + 2, Y: y + start + offset})
 		if m.selectedTopic != idx {
 			t.Fatalf("expected selected topic %d, got %d", idx, m.selectedTopic)
 		}

--- a/update.go
+++ b/update.go
@@ -307,14 +307,14 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 			}
 		}
 	case tea.MouseMsg:
-		if msg.Type == tea.MouseWheelUp || msg.Type == tea.MouseWheelDown {
+		if msg.Action == tea.MouseActionPress && (msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown) {
 			if m.focusOrder[m.focusIndex] == "history" {
 				var hCmd tea.Cmd
 				m.history, hCmd = m.history.Update(msg)
 				cmds = append(cmds, hCmd)
 			}
 		}
-		if msg.Type == tea.MouseLeft {
+		if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
 			cmds = append(cmds, m.focusFromMouse(msg.Y))
 		}
 		if m.focusOrder[m.focusIndex] == "topics" {
@@ -358,9 +358,9 @@ func (m *model) handleTopicsClick(msg tea.MouseMsg) {
 		return
 	}
 	m.selectedTopic = idx
-	if msg.Type == tea.MouseLeft {
+	if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
 		m.toggleTopic(idx)
-	} else if msg.Type == tea.MouseRight {
+	} else if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonRight {
 		name := m.topics[idx].title
 		m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), func() {
 			m.removeTopic(idx)


### PR DESCRIPTION
## Summary
- replace deprecated `MouseLeft` and `MouseRight` checks with `MouseAction`/`MouseButton`
- update mouse wheel handling
- adjust tests for new mouse API

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68855c85ccec8324baea5d0ac860add9