### PR TITLE
Subscribe to topics on connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ In the interface:
 - **Esc** navigates back within menus without quitting.
 - **Ctrl+D** exits the program.
 - Left-click a topic chip to toggle it and middle-click to remove it.
+- Active topics are automatically subscribed when you connect to a broker.
 - Clicking on any pane or input field focuses it.
 
 All `Ctrl` shortcuts are global, so they work even when an input field is active.

--- a/model.go
+++ b/model.go
@@ -283,3 +283,14 @@ func (m *model) startConfirm(prompt string, action func()) {
 	m.prevMode = m.mode
 	m.mode = modeConfirmDelete
 }
+
+func (m *model) subscribeActiveTopics() {
+	if m.mqttClient == nil {
+		return
+	}
+	for _, t := range m.topics {
+		if t.active {
+			m.mqttClient.Subscribe(t.title, 0, nil)
+		}
+	}
+}

--- a/update.go
+++ b/update.go
@@ -387,6 +387,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 						m.mqttClient = client
 						m.activeConn = p.Name
 						m.restoreState(p.Name)
+						m.subscribeActiveTopics()
 						brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
 						m.connection = "Connected to " + brokerURL
 						m.mode = modeClient
@@ -426,6 +427,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					m.mqttClient = client
 					m.activeConn = p.Name
 					m.restoreState(p.Name)
+					m.subscribeActiveTopics()
 					brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
 					m.connection = "Connected to " + brokerURL
 					m.mode = modeClient


### PR DESCRIPTION
## Summary
- subscribe to all active topics immediately after connecting
- document that active topics are automatically subscribed

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68856a203f088324a120e8591dcc53a8