### PR TITLE
Enhance broker manager UI

### DIFF
--- a/connectionform.go
+++ b/connectionform.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 type formField interface {
@@ -326,7 +325,6 @@ func (f connectionForm) Update(msg tea.Msg) (connectionForm, tea.Cmd) {
 }
 
 func (f connectionForm) View() string {
-	border := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1).BorderForeground(lipgloss.Color("63"))
 	var s string
 	labels := []string{
 		"Name",
@@ -365,7 +363,7 @@ func (f connectionForm) View() string {
 		s += fmt.Sprintf("%s: %s\n", label, in.View())
 	}
 	s += "\nPress Enter to save or Esc to cancel"
-	return border.Render(s)
+	return s
 }
 
 func (f connectionForm) Profile() Profile {

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -113,3 +113,11 @@ func (m *MQTTClient) Unsubscribe(topic string) error {
 	}
 	return nil
 }
+
+// Disconnect cleanly closes the connection to the broker.
+func (m *MQTTClient) Disconnect() {
+	if m.Client != nil && m.Client.IsConnected() {
+		// Allow up to 250 milliseconds for pending work to complete.
+		m.Client.Disconnect(250)
+	}
+}

--- a/update.go
+++ b/update.go
@@ -184,6 +184,15 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 					clipboard.WriteAll(text)
 				}
 			}
+		case "ctrl+x":
+			if m.mqttClient != nil {
+				m.mqttClient.Disconnect()
+				m.connections.Statuses[m.activeConn] = "disconnected"
+				m.refreshConnectionItems()
+				m.connection = ""
+				m.activeConn = ""
+				m.mqttClient = nil
+			}
 		case "space":
 			if m.focusOrder[m.focusIndex] == "history" {
 				idx := m.history.Index()
@@ -468,7 +477,10 @@ func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
 		return m, nil
 	}
 	var cmd tea.Cmd
-	m.connections.ConnectionsList, _ = m.connections.ConnectionsList.Update(msg)
+	switch msg.(type) {
+	case tea.WindowSizeMsg, tea.MouseMsg:
+		m.connections.ConnectionsList, _ = m.connections.ConnectionsList.Update(msg)
+	}
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {

--- a/views.go
+++ b/views.go
@@ -94,18 +94,20 @@ func (m model) viewConnections() string {
 	listView := m.connections.ConnectionsList.View()
 	help := "[enter] connect  [a]dd [e]dit [d]elete  [esc] back"
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return borderStyle.Width(m.width - 2).Height(m.height - 2).Render(content)
+	return legendBox(content, "Brokers", m.width-2, true)
 }
 
 func (m model) viewForm() string {
 	if m.connForm == nil {
 		return ""
 	}
-	listView := m.connections.ConnectionsList.View()
-	formView := m.connForm.View()
-	left := borderStyle.Width(m.width/2 - 2).Render(listView)
-	right := borderStyle.Width(m.width/2 - 2).Render(formView)
-	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+	listView := legendBox(m.connections.ConnectionsList.View(), "Brokers", m.width/2-2, false)
+	formLabel := "Add Broker"
+	if m.connForm.index >= 0 {
+		formLabel = "Edit Broker"
+	}
+	formView := legendBox(m.connForm.View(), formLabel, m.width/2-2, false)
+	return lipgloss.JoinHorizontal(lipgloss.Top, listView, formView)
 }
 
 func (m model) viewConfirmDelete() string {


### PR DESCRIPTION
## Summary
- allow disconnecting from the current broker with `Ctrl+X`
- show "Brokers" label inside the border like other panes
- avoid double border around the connection form
- stop arrow keys from moving the broker list when editing

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68856fbef22c8324ae3616339d94fe91