### PR TITLE
UI shortcut fixes and box style guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker
 - Favor multi-line text areas where users might paste formatted data.
 - Always consider usability and look for ways to improve it.
 
+### UI Guidelines
+- Use `legendBox` or its variants for all boxed sections.
+- Highlight the selected box using the focused style (pink).
+- Present keyboard shortcuts consistently across views and ensure they behave the same everywhere.
+
 ## Test Info
 `ExampleSet_manual` in `keyring_util_test.go` requires a real keyring. It does not run during `go test ./...` and can be executed manually if needed.
 

--- a/connectionform.go
+++ b/connectionform.go
@@ -362,7 +362,7 @@ func (f connectionForm) View() string {
 		}
 		s += fmt.Sprintf("%s: %s\n", label, in.View())
 	}
-	s += "\nPress Enter to save or Esc to cancel"
+	s += "\n" + infoStyle.Render("[enter] save  [esc] cancel")
 	return s
 }
 

--- a/update.go
+++ b/update.go
@@ -411,14 +411,12 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 						m.mode = modeClient
 					}
 				}
-			case "esc":
-				m.mode = modeClient
 			}
 			break
 		}
 		switch msg.String() {
-		case "esc":
-			m.mode = modeClient
+		case "ctrl+d":
+			return m, tea.Quit
 		case "a":
 			f := newConnectionForm(Profile{}, -1)
 			m.connForm = &f
@@ -484,6 +482,8 @@ func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "ctrl+d":
+			return m, tea.Quit
 		case "esc":
 			m.mode = modeConnections
 			m.connForm = nil
@@ -510,6 +510,8 @@ func (m *model) updateConfirmDelete(msg tea.Msg) (model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "ctrl+d":
+			return *m, tea.Quit
 		case "y":
 			if m.confirmAction != nil {
 				m.confirmAction()
@@ -530,6 +532,8 @@ func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "ctrl+d":
+			return m, tea.Quit
 		case "esc":
 			m.mode = modeClient
 		case "d":
@@ -564,6 +568,8 @@ func (m model) updatePayloads(msg tea.Msg) (model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "ctrl+d":
+			return m, tea.Quit
 		case "esc":
 			m.mode = modeClient
 		case "d":

--- a/views.go
+++ b/views.go
@@ -92,7 +92,7 @@ func (m *model) viewClient() string {
 
 func (m model) viewConnections() string {
 	listView := m.connections.ConnectionsList.View()
-	help := "[enter] connect  [a]dd [e]dit [d]elete  [esc] back"
+	help := infoStyle.Render("[enter] connect  [a]dd [e]dit [d]elete")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
 	return legendBox(content, "Brokers", m.width-2, true)
 }
@@ -106,7 +106,7 @@ func (m model) viewForm() string {
 	if m.connForm.index >= 0 {
 		formLabel = "Edit Broker"
 	}
-	formView := legendBox(m.connForm.View(), formLabel, m.width/2-2, false)
+	formView := legendBox(m.connForm.View(), formLabel, m.width/2-2, true)
 	return lipgloss.JoinHorizontal(lipgloss.Top, listView, formView)
 }
 


### PR DESCRIPTION
## Summary
- handle `ctrl+d` to quit from all views
- remove `esc` from broker list and update help text
- highlight broker form pane and format its help line
- document UI guidelines in `AGENTS.md`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688575d0879483248af6a1d141e38659