### PR TITLE
Show client ID in info bar

### DIFF
--- a/views.go
+++ b/views.go
@@ -41,7 +41,14 @@ func layoutChips(chips []string, width int) (string, []chipBound) {
 }
 
 func (m *model) viewClient() string {
-	infoLine := infoStyle.Render("Info: Ctrl+S publishes, Ctrl+B brokers, Ctrl+T topics, Ctrl+P payloads.", m.connection)
+	infoShortcuts := infoStyle.Render("Info: Ctrl+S publishes, Ctrl+B brokers, Ctrl+T topics, Ctrl+P payloads.")
+	clientID := ""
+	if m.mqttClient != nil {
+		r := m.mqttClient.Client.OptionsReader()
+		clientID = r.ClientID()
+	}
+	connLine := infoStyle.Render(strings.TrimSpace(m.connection + " " + clientID))
+	infoLine := lipgloss.JoinVertical(lipgloss.Left, infoShortcuts, connLine)
 
 	var chips []string
 	for i, t := range m.topics {


### PR DESCRIPTION
## Summary
- display MQTT client ID along with current connection info

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885814bcb24832497b20051268b08d5