### PR TITLE
Fix header clipping

### DIFF
--- a/update.go
+++ b/update.go
@@ -630,7 +630,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.messageInput.SetWidth(msg.Width - 4)
 		m.history.SetSize(msg.Width-4, (msg.Height-1)/3+10)
 		m.viewport.Width = msg.Width
-		m.viewport.Height = msg.Height - 1
+		// Reserve two lines for the info header at the top of the view.
+		m.viewport.Height = msg.Height - 2
 		return m, nil
 	}
 

--- a/views.go
+++ b/views.go
@@ -93,7 +93,8 @@ func (m *model) viewClient() string {
 	box := lipgloss.NewStyle().Width(m.width).Padding(0, 1, 1, 1).Render(content)
 	m.viewport.SetContent(box)
 	m.viewport.Width = m.width
-	m.viewport.Height = m.height - 1
+	// Deduct two lines for the info header rendered above the viewport.
+	m.viewport.Height = m.height - 2
 	return lipgloss.JoinVertical(lipgloss.Left, infoLine, m.viewport.View())
 }
 


### PR DESCRIPTION
## Summary
- reserve two rows for info header when setting viewport height
- apply the same logic on window resize handling

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688582d670dc83249dc431a644f2f75b