### PR TITLE
Update shortcuts and status styling

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -17,6 +17,7 @@ var (
 	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
 	chipInactive = chipStyle.Foreground(lipgloss.Color("240"))
 	infoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).PaddingLeft(1)
+	connStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(1)
 )
 
 func legendBox(content, label string, width int, focused bool) string {

--- a/views.go
+++ b/views.go
@@ -41,13 +41,13 @@ func layoutChips(chips []string, width int) (string, []chipBound) {
 }
 
 func (m *model) viewClient() string {
-	infoShortcuts := infoStyle.Render("Info: Ctrl+S publishes, Ctrl+B brokers, Ctrl+T topics, Ctrl+P payloads.")
+	infoShortcuts := infoStyle.Render("Switch views: Ctrl+B brokers, Ctrl+T topics, Ctrl+P payloads.")
 	clientID := ""
 	if m.mqttClient != nil {
 		r := m.mqttClient.Client.OptionsReader()
 		clientID = r.ClientID()
 	}
-	connLine := infoStyle.Render(strings.TrimSpace(m.connection + " " + clientID))
+	connLine := connStyle.Render(strings.TrimSpace(m.connection + " " + clientID))
 	infoLine := lipgloss.JoinVertical(lipgloss.Left, infoShortcuts, connLine)
 
 	var chips []string
@@ -69,7 +69,7 @@ func (m *model) viewClient() string {
 	chipContent, bounds := layoutChips(chips, m.width-4)
 	topicsBox := legendBox(chipContent, "Topics", m.width-2, topicsFocused)
 	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-2, topicFocused)
-	messageBox := legendBox(m.messageInput.View(), "Message", m.width-2, messageFocused)
+	messageBox := legendBox(m.messageInput.View(), "Message (Ctrl+S publishes)", m.width-2, messageFocused)
 	messagesBox := legendGreenBox(m.history.View(), "History (Ctrl+C copy)", m.width-2, historyFocused)
 
 	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)


### PR DESCRIPTION
## Summary
- tweak message box header to include publish shortcut
- show connection details in grey
- drop publish shortcut from info line and rename it

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885852735848324955956f2fccd92c8