### PR TITLE
Add environment variable password option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ In the interface:
 - **Ctrl+S** publishes the message currently in the editor.
 - **Ctrl+Enter** also publishes the current message.
 - **Ctrl+B** opens the broker manager where you can add, edit or delete MQTT profiles.
+- **x** disconnects from the current broker in the broker manager.
 - **Ctrl+T** manages subscribed topics.
 - **Ctrl+P** manages stored payloads.
 - **Ctrl+C** copies the currently selected history entry.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ so multiple connections remain unique.
 
 Passwords can be stored securely using the operating system keyring. You may also set the `MQTT_PASSWORD` environment variable to override the stored password at runtime.
 
+Each broker profile can optionally load all of its settings from environment variables instead of `config.toml`. Enable **Load from env** when editing a profile and set variables using the pattern `GOEMQUTITI_<NAME>_<FIELD>` where `<NAME>` is the profile name in uppercase. For example, the password for a profile named `local` is read from `GOEMQUTITI_LOCAL_PASSWORD`.
+
 In the interface:
 
 - **Tab** cycles focus between the topic input, message editor, and topic chips.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ so multiple connections remain unique.
 
 Passwords can be stored securely using the operating system keyring. You may also set the `MQTT_PASSWORD` environment variable to override the stored password at runtime.
 
-Each broker profile can optionally load all of its settings from environment variables instead of `config.toml`. Enable **Load from env** when editing a profile and set variables using the pattern `GOEMQUTITI_<NAME>_<FIELD>` where `<NAME>` is the profile name in uppercase. For example, the password for a profile named `local` is read from `GOEMQUTITI_LOCAL_PASSWORD`.
+Each broker profile can optionally load all of its settings from environment variables instead of `config.toml`. Enable **Load from env** when editing a profile and set variables using the pattern `GOEMQUTITI_<NAME>_<FIELD>`. The `<NAME>` portion is derived from the profile name: letters are upper‑cased and any other characters become underscores. For example, a profile named `local broker` would use variables like `GOEMQUTITI_LOCAL_BROKER_PASSWORD`.
 
 In the interface:
 

--- a/colors.go
+++ b/colors.go
@@ -1,0 +1,17 @@
+package main
+
+import "github.com/charmbracelet/lipgloss"
+
+// Color palette used throughout the TUI. Keeping these constants in one place
+// ensures a consistent look and makes it easy to tweak the theme.
+const (
+	colPink     = lipgloss.Color("205") // focused elements
+	colBlue     = lipgloss.Color("63")  // accents and borders
+	colGreen    = lipgloss.Color("34")  // success borders
+	colGray     = lipgloss.Color("240") // blurred or secondary text
+	colCyan     = lipgloss.Color("51")  // info box borders
+	colPurple   = lipgloss.Color("212") // selection highlight borders
+	colPub      = lipgloss.Color("219") // published payload text
+	colSub      = lipgloss.Color("81")  // subscribed payload text
+	colDarkGray = lipgloss.Color("237") // background of selected history lines
+)

--- a/connectionform.go
+++ b/connectionform.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -142,6 +143,8 @@ const (
 	idxIDSuffix
 	idxUsername
 	idxPassword
+	idxPasswordFromEnv
+	idxPasswordEnv
 	idxSSL
 	idxMQTTVersion
 	idxConnectTimeout
@@ -176,28 +179,34 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 		p.ClientID,
 		"", // checkbox for rand suffix
 		p.Username,
-		"",
-		"", // placeholder for checkbox
+		p.Password,
+		"", // checkbox: password from env
+		p.PasswordEnvVar,
+		"", // SSL checkbox
 		p.MQTTVersion,
 		fmt.Sprintf("%d", p.ConnectTimeout),
 		fmt.Sprintf("%d", p.KeepAlive),
 		fmt.Sprintf("%d", p.QoS),
-		"", // checkbox
+		"", // auto reconnect checkbox
 		fmt.Sprintf("%d", p.ReconnectPeriod),
-		"", // checkbox
+		"", // clean start checkbox
 		fmt.Sprintf("%d", p.SessionExpiry),
 		fmt.Sprintf("%d", p.ReceiveMaximum),
 		fmt.Sprintf("%d", p.MaximumPacketSize),
 		fmt.Sprintf("%d", p.TopicAliasMaximum),
-		"", // checkbox
-		"", // checkbox
-		"", // checkbox
+		"", // request response info checkbox
+		"", // request problem info checkbox
+		"", // last will enabled checkbox
 		p.LastWillTopic,
 		fmt.Sprintf("%d", p.LastWillQos),
-		"", // checkbox
+		"", // last will retain checkbox
 		p.LastWillPayload,
 	}
 
+	envName := "GOEMQUTITI_<NAME>_PASSWORD"
+	if p.Name != "" {
+		envName = fmt.Sprintf("GOEMQUTITI_%s_PASSWORD", strings.ToUpper(p.Name))
+	}
 	placeholders := []string{
 		"Name",
 		"Schema",
@@ -207,6 +216,8 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 		"Random ID suffix",
 		"Username",
 		pwKey,
+		"Use env var",
+		envName,
 		"SSL/TLS",
 		"MQTT Version",
 		"Connect Timeout (s)",
@@ -230,14 +241,15 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 
 	fields := make([]formField, len(values))
 	boolIndices := map[int]bool{
-		idxSSL:           true,
-		idxAutoReconnect: true,
-		idxCleanStart:    true,
-		idxRequestResp:   true,
-		idxRequestProb:   true,
-		idxWillEnable:    true,
-		idxWillRetain:    true,
-		idxIDSuffix:      true,
+		idxIDSuffix:        true,
+		idxPasswordFromEnv: true,
+		idxSSL:             true,
+		idxAutoReconnect:   true,
+		idxCleanStart:      true,
+		idxRequestResp:     true,
+		idxRequestProb:     true,
+		idxWillEnable:      true,
+		idxWillRetain:      true,
 	}
 
 	selectOptions := map[int][]string{
@@ -249,6 +261,7 @@ func newConnectionForm(p Profile, idx int) connectionForm {
 
 	boolValues := []bool{
 		p.RandomIDSuffix,
+		p.PasswordFromEnv,
 		p.SSL,
 		p.AutoReconnect,
 		p.CleanStart,
@@ -335,6 +348,8 @@ func (f connectionForm) View() string {
 		"Random ID suffix",
 		"Username",
 		"Password",
+		"Use env var",
+		"Env var name",
 		"SSL/TLS",
 		"MQTT Version",
 		"Connect Timeout (s)",
@@ -379,6 +394,8 @@ func (f connectionForm) Profile() Profile {
 	p.ClientID = vals[idxClientID]
 	p.Username = vals[idxUsername]
 	p.Password = vals[idxPassword]
+	fmt.Sscan(vals[idxPasswordFromEnv], &p.PasswordFromEnv)
+	p.PasswordEnvVar = vals[idxPasswordEnv]
 	fmt.Sscan(vals[idxSSL], &p.SSL)
 	p.MQTTVersion = vals[idxMQTTVersion]
 	fmt.Sscan(vals[idxConnectTimeout], &p.ConnectTimeout)

--- a/connections.go
+++ b/connections.go
@@ -236,11 +236,28 @@ func retrievePasswordFromKeyring(password string) (string, error) {
 // applyEnvVars loads all profile fields from environment variables when FromEnv is set.
 // Environment variable names use the pattern GOEMQUTITI_<NAME>_<FIELD>, where
 // <NAME> is the uppercased profile name and <FIELD> matches the TOML field name.
+func sanitizeEnvName(name string) string {
+	upper := strings.ToUpper(name)
+	var b strings.Builder
+	for _, r := range upper {
+		if r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+func envPrefix(name string) string {
+	return "GOEMQUTITI_" + sanitizeEnvName(name) + "_"
+}
+
 func applyEnvVars(p *Profile) {
 	if !p.FromEnv {
 		return
 	}
-	prefix := fmt.Sprintf("GOEMQUTITI_%s_", strings.ToUpper(p.Name))
+	prefix := envPrefix(p.Name)
 	rv := reflect.ValueOf(p).Elem()
 	rt := rv.Type()
 	for i := 0; i < rt.NumField(); i++ {

--- a/connectionsdelegate.go
+++ b/connectionsdelegate.go
@@ -20,10 +20,10 @@ func (d connectionDelegate) Render(w io.Writer, m list.Model, index int, item li
 	width := m.Width()
 	border := " "
 	if index == m.Index() {
-		border = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Render("┃")
+		border = lipgloss.NewStyle().Foreground(colPurple).Render("┃")
 	}
 	name := lipgloss.PlaceHorizontal(width-2, lipgloss.Left, ci.title)
-	status := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(ci.status)
+	status := lipgloss.NewStyle().Foreground(colGray).Render(ci.status)
 	status = lipgloss.PlaceHorizontal(width-2, lipgloss.Left, status)
 	fmt.Fprintf(w, "%s %s\n%s %s", border, name, border, status)
 }

--- a/historydelegate.go
+++ b/historydelegate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // historyDelegate renders history items with two lines and supports highlighting
@@ -55,9 +56,12 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		lines = append(lines, line1)
 	}
 	for _, l := range strings.Split(hi.payload, "\n") {
-		rendered := lipgloss.PlaceHorizontal(innerWidth, align,
-			lipgloss.NewStyle().Foreground(msgColor).Render(l))
-		lines = append(lines, rendered)
+		wrapped := ansi.Wrap(l, innerWidth, " ")
+		for _, wl := range strings.Split(wrapped, "\n") {
+			rendered := lipgloss.PlaceHorizontal(innerWidth, align,
+				lipgloss.NewStyle().Foreground(msgColor).Render(wl))
+			lines = append(lines, rendered)
+		}
 	}
 	if _, ok := d.m.selectedHistory[index]; ok {
 		for i, l := range lines {

--- a/historydelegate.go
+++ b/historydelegate.go
@@ -64,7 +64,7 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 			lines[i] = lipgloss.NewStyle().Background(colDarkGray).Render(l)
 		}
 	}
-	border := " "
+	border := lipgloss.NewStyle().Foreground(colGray).Render("┃")
 	if _, ok := d.m.selectedHistory[index]; ok {
 		border = lipgloss.NewStyle().Foreground(colBlue).Render("┃")
 	}

--- a/historydelegate.go
+++ b/historydelegate.go
@@ -27,16 +27,16 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	switch hi.kind {
 	case "sub":
 		label = fmt.Sprintf("SUB %s:", hi.topic)
-		lblColor = lipgloss.Color("205")
-		msgColor = lipgloss.Color("219")
+		lblColor = colPink
+		msgColor = colPub
 	case "pub":
 		label = fmt.Sprintf("PUB %s:", hi.topic)
-		lblColor = lipgloss.Color("63")
-		msgColor = lipgloss.Color("81")
+		lblColor = colBlue
+		msgColor = colSub
 	default:
 		label = ""
-		lblColor = lipgloss.Color("240")
-		msgColor = lipgloss.Color("240")
+		lblColor = colGray
+		msgColor = colGray
 	}
 	align := lipgloss.Left
 	if hi.kind == "pub" {
@@ -61,15 +61,15 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	}
 	if _, ok := d.m.selectedHistory[index]; ok {
 		for i, l := range lines {
-			lines[i] = lipgloss.NewStyle().Background(lipgloss.Color("237")).Render(l)
+			lines[i] = lipgloss.NewStyle().Background(colDarkGray).Render(l)
 		}
 	}
 	border := " "
 	if _, ok := d.m.selectedHistory[index]; ok {
-		border = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Render("┃")
+		border = lipgloss.NewStyle().Foreground(colBlue).Render("┃")
 	}
 	if index == d.m.history.Index() {
-		border = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Render("┃")
+		border = lipgloss.NewStyle().Foreground(colPurple).Render("┃")
 	}
 	for i, l := range lines {
 		lines[i] = border + " " + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l)

--- a/historydelegate.go
+++ b/historydelegate.go
@@ -34,8 +34,9 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		lblColor = lipgloss.Color("63")
 		msgColor = lipgloss.Color("81")
 	default:
-		fmt.Fprint(w, lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Width(width).Render(hi.payload))
-		return
+		label = ""
+		lblColor = lipgloss.Color("240")
+		msgColor = lipgloss.Color("240")
 	}
 	align := lipgloss.Left
 	if hi.kind == "pub" {
@@ -45,12 +46,14 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	if innerWidth < 0 {
 		innerWidth = 0
 	}
-	line1 := lipgloss.PlaceHorizontal(innerWidth, align,
-		lipgloss.NewStyle().Foreground(lblColor).Render(label))
 
 	// Support multi-line payloads by aligning each line individually
 	var lines []string
-	lines = append(lines, line1)
+	if hi.kind != "log" {
+		line1 := lipgloss.PlaceHorizontal(innerWidth, align,
+			lipgloss.NewStyle().Foreground(lblColor).Render(label))
+		lines = append(lines, line1)
+	}
 	for _, l := range strings.Split(hi.payload, "\n") {
 		rendered := lipgloss.PlaceHorizontal(innerWidth, align,
 			lipgloss.NewStyle().Foreground(msgColor).Render(l))

--- a/model.go
+++ b/model.go
@@ -137,7 +137,7 @@ func initialModel(conns *Connections) *model {
 	ti.Focus()
 	ti.CharLimit = 32
 	ti.Prompt = "> "
-	ti.PromptStyle = lipgloss.NewStyle().Foreground(colDarkGray)
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(colGray)
 	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(colGray)
 	ti.Cursor.Style = cursorStyle
 	ti.TextStyle = focusedStyle

--- a/model.go
+++ b/model.go
@@ -138,6 +138,7 @@ func initialModel(conns *Connections) *model {
 	ti.CharLimit = 32
 	ti.Prompt = "> "
 	ti.PromptStyle = lipgloss.NewStyle().Foreground(colGray)
+	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(colGray)
 	ti.Cursor.Style = cursorStyle
 	ti.TextStyle = focusedStyle
 	// Defer width assignment until we know the terminal size

--- a/model.go
+++ b/model.go
@@ -137,6 +137,7 @@ func initialModel(conns *Connections) *model {
 	ti.Focus()
 	ti.CharLimit = 32
 	ti.Prompt = "> "
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	ti.Cursor.Style = cursorStyle
 	ti.TextStyle = focusedStyle
 	// Defer width assignment until we know the terminal size

--- a/model.go
+++ b/model.go
@@ -137,7 +137,7 @@ func initialModel(conns *Connections) *model {
 	ti.Focus()
 	ti.CharLimit = 32
 	ti.Prompt = "> "
-	ti.PromptStyle = lipgloss.NewStyle().Foreground(colGray)
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(colDarkGray)
 	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(colGray)
 	ti.Cursor.Style = cursorStyle
 	ti.TextStyle = focusedStyle

--- a/model.go
+++ b/model.go
@@ -54,17 +54,17 @@ type historyItem struct {
 func (h historyItem) FilterValue() string { return h.payload }
 func (h historyItem) Title() string {
 	var label string
-	color := lipgloss.Color("63")
+	color := colBlue
 	switch h.kind {
 	case "sub":
 		label = "SUB"
-		color = lipgloss.Color("205")
+		color = colPink
 	case "pub":
 		label = "PUB"
-		color = lipgloss.Color("63")
+		color = colBlue
 	default:
 		label = "LOG"
-		color = lipgloss.Color("240")
+		color = colGray
 	}
 	return lipgloss.NewStyle().Foreground(color).Render(fmt.Sprintf("%s %s: %s", label, h.topic, h.payload))
 }
@@ -137,7 +137,7 @@ func initialModel(conns *Connections) *model {
 	ti.Focus()
 	ti.CharLimit = 32
 	ti.Prompt = "> "
-	ti.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(colGray)
 	ti.Cursor.Style = cursorStyle
 	ti.TextStyle = focusedStyle
 	// Defer width assignment until we know the terminal size
@@ -150,7 +150,7 @@ func initialModel(conns *Connections) *model {
 	ta.SetPromptFunc(0, func(i int) string {
 		return fmt.Sprintf("%d> ", i+1)
 	})
-	promptColor := lipgloss.Color("240")
+	promptColor := colGray
 	ta.FocusedStyle.Prompt = lipgloss.NewStyle().Foreground(promptColor)
 	ta.BlurredStyle.Prompt = lipgloss.NewStyle().Foreground(promptColor)
 	ta.Blur()

--- a/styles.go
+++ b/styles.go
@@ -8,30 +8,30 @@ import (
 )
 
 var (
-	focusedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-	blurredStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	focusedStyle = lipgloss.NewStyle().Foreground(colPink)
+	blurredStyle = lipgloss.NewStyle().Foreground(colGray)
 	cursorStyle  = focusedStyle
 	noCursor     = lipgloss.NewStyle()
-	borderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1)
-	greenBorder  = borderStyle.BorderForeground(lipgloss.Color("34"))
-	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
-	chipInactive = chipStyle.Foreground(lipgloss.Color("240"))
-	infoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("63")).PaddingLeft(1)
-	connStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(1)
+	borderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(colBlue).Padding(0, 1)
+	greenBorder  = borderStyle.BorderForeground(colGreen)
+	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(colBlue).Faint(true)
+	chipInactive = chipStyle.Foreground(colGray)
+	infoStyle    = lipgloss.NewStyle().Foreground(colBlue).PaddingLeft(1)
+	connStyle    = lipgloss.NewStyle().Foreground(colGray).PaddingLeft(1)
 )
 
 func legendBox(content, label string, width int, focused bool) string {
-	color := lipgloss.Color("63")
+	color := colBlue
 	if focused {
-		color = lipgloss.Color("205")
+		color = colPink
 	}
 	return legendStyledBox(content, label, width, color)
 }
 
 func legendGreenBox(content, label string, width int, focused bool) string {
-	color := lipgloss.Color("34")
+	color := colGreen
 	if focused {
-		color = lipgloss.Color("205")
+		color = colPink
 	}
 	return legendStyledBox(content, label, width, color)
 }
@@ -51,7 +51,7 @@ func legendStyledBox(content, label string, width int, color lipgloss.Color) str
 	}
 
 	b := lipgloss.RoundedBorder()
-	cy := lipgloss.Color("51")
+	cy := colCyan
 	top := lipgloss.NewStyle().Foreground(color).Render(
 		b.TopLeft+" "+label+" "+strings.Repeat(b.Top, width-lipgloss.Width(label)-4),
 	) + lipgloss.NewStyle().Foreground(cy).Render(b.TopRight)

--- a/update.go
+++ b/update.go
@@ -437,14 +437,8 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 				if i >= 0 && i < len(m.connections.Profiles) {
 					p := m.connections.Profiles[i]
 					flushStatus(m.statusChan)
-					if p.PasswordFromEnv {
-						if val, ok := os.LookupEnv(p.PasswordEnvVar); ok {
-							p.Password = val
-						} else {
-							m.connection = fmt.Sprintf("Missing password env %s", p.PasswordEnvVar)
-							m.appendHistory("", "", "log", m.connection)
-							return m, nil
-						}
+					if p.FromEnv {
+						applyEnvVars(&p)
 					} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 						p.Password = env
 					}
@@ -476,14 +470,8 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			if i >= 0 && i < len(m.connections.Profiles) {
 				p := m.connections.Profiles[i]
 				flushStatus(m.statusChan)
-				if p.PasswordFromEnv {
-					if val, ok := os.LookupEnv(p.PasswordEnvVar); ok {
-						p.Password = val
-					} else {
-						m.connection = fmt.Sprintf("Missing password env %s", p.PasswordEnvVar)
-						m.appendHistory("", "", "log", m.connection)
-						return m, nil
-					}
+				if p.FromEnv {
+					applyEnvVars(&p)
 				} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 					p.Password = env
 				}

--- a/update.go
+++ b/update.go
@@ -491,6 +491,15 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					m.refreshConnectionItems()
 				})
 			}
+		case "x":
+			if m.mqttClient != nil {
+				m.mqttClient.Disconnect()
+				m.connections.Statuses[m.activeConn] = "disconnected"
+				m.refreshConnectionItems()
+				m.connection = ""
+				m.activeConn = ""
+				m.mqttClient = nil
+			}
 		}
 	}
 	m.connections.ConnectionsList, cmd = m.connections.ConnectionsList.Update(msg)

--- a/views.go
+++ b/views.go
@@ -100,8 +100,13 @@ func (m *model) viewClient() string {
 
 func (m model) viewConnections() string {
 	listView := m.connections.ConnectionsList.View()
-	help := infoStyle.Render("[enter] connect  [a]dd [e]dit [d]elete")
-	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
+	help := infoStyle.Render("[enter] connect  [x] disconnect  [a]dd [e]dit [d]elete")
+	var parts []string
+	if strings.TrimSpace(m.connection) != "" {
+		parts = append(parts, connStyle.Render(strings.TrimSpace(m.connection)))
+	}
+	parts = append(parts, listView, help)
+	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
 	return legendBox(content, "Brokers", m.width-2, true)
 }
 

--- a/views.go
+++ b/views.go
@@ -57,7 +57,7 @@ func (m *model) viewClient() string {
 			st = chipInactive
 		}
 		if m.focusOrder[m.focusIndex] == "topics" && i == m.selectedTopic {
-			st = st.BorderForeground(lipgloss.Color("212"))
+			st = st.BorderForeground(colPurple)
 		}
 		chips = append(chips, st.Render(t.title))
 	}
@@ -119,7 +119,7 @@ func (m model) viewForm() string {
 }
 
 func (m model) viewConfirmDelete() string {
-	border := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1)
+	border := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colBlue).Padding(0, 1)
 	return border.Render(m.confirmPrompt)
 }
 


### PR DESCRIPTION
## Summary
- allow profiles to load passwords from environment variables
- flush stale status messages before connecting
- style log entries with borders
- darken topic prompt arrow

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885e294646483249d7a0183519175b1