### PR TITLE
Fix history wrapping and broker info display

### DIFF
--- a/connectionsdelegate.go
+++ b/connectionsdelegate.go
@@ -26,6 +26,6 @@ func (d connectionDelegate) Render(w io.Writer, m list.Model, index int, item li
 	status := lipgloss.NewStyle().Foreground(colGray).Render(ci.status)
 	status = lipgloss.PlaceHorizontal(width-2, lipgloss.Left, status)
 	detail := lipgloss.PlaceHorizontal(width-2, lipgloss.Left,
-		lipgloss.NewStyle().Foreground(colDarkGray).Render(ci.detail))
+		lipgloss.NewStyle().Foreground(colGray).Render(ci.detail))
 	fmt.Fprintf(w, "%s %s\n%s %s\n%s %s", border, name, border, status, border, detail)
 }

--- a/styles.go
+++ b/styles.go
@@ -41,14 +41,6 @@ func legendStyledBox(content, label string, width int, color lipgloss.Color) str
 	if width < lipgloss.Width(label)+4 {
 		width = lipgloss.Width(label) + 4
 	}
-	// Ensure the box is wide enough for the content while
-	// ignoring trailing whitespace that might come from inputs
-	for _, l := range strings.Split(content, "\n") {
-		l = strings.TrimRightFunc(l, unicode.IsSpace)
-		if w := lipgloss.Width(l) + 2; w > width {
-			width = w
-		}
-	}
 
 	b := lipgloss.RoundedBorder()
 	cy := colCyan

--- a/views.go
+++ b/views.go
@@ -101,12 +101,7 @@ func (m *model) viewClient() string {
 func (m model) viewConnections() string {
 	listView := m.connections.ConnectionsList.View()
 	help := infoStyle.Render("[enter] connect  [x] disconnect  [a]dd [e]dit [d]elete")
-	var parts []string
-	if strings.TrimSpace(m.connection) != "" {
-		parts = append(parts, connStyle.Render(strings.TrimSpace(m.connection)))
-	}
-	parts = append(parts, listView, help)
-	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
 	return legendBox(content, "Brokers", m.width-2, true)
 }
 


### PR DESCRIPTION
## Summary
- ensure connection errors use colGray
- drop duplicate connection message in brokers view
- keep legend box width fixed

## Testing
- `go vet ./...`
- `go test ./...` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6885f763aab083248506b180157e0cee