### PR TITLE
Refactor history storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ In the interface:
   `topic=<list>` comma separated, `start=<RFC3339 time>`, `end=<RFC3339 time>`
   and free text to match payloads. Example:
   `topic=sensors/start start=2024-01-01T00:00:00Z payload=error`.
-  The history log is stored in BadgerDB under `~/.emqutiti/history` so messages
-  remain searchable across sessions.
+  The history log is stored in BadgerDB under
+  `~/.emqutiti/history/<profile>` so messages remain searchable per profile.
 - **Esc** navigates back within menus without quitting.
 - **Ctrl+D** exits the program.
 - Left-click a topic chip to toggle it and middle-click to remove it.

--- a/main.go
+++ b/main.go
@@ -77,8 +77,8 @@ func main() {
 		log.Fatalf("Error running program: %v", err)
 	}
 	if m, ok := finalModel.(*model); ok {
-		if m.tracer != nil {
-			m.tracer.Close()
+		if m.store != nil {
+			m.store.Close()
 		}
 	}
 }

--- a/model.go
+++ b/model.go
@@ -10,8 +10,8 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"goemqutiti/history"
 	"goemqutiti/ui"
-	"goemqutiti/trace"
 )
 
 type connectionItem struct {
@@ -107,7 +107,7 @@ type model struct {
 	activeConn      string
 	history         list.Model
 	historyItems    []historyItem
-	tracer          *trace.Index
+	store           *history.Index
 	topicInput      textinput.Model
 	messageInput    textarea.Model
 	payloads        []payloadItem
@@ -217,7 +217,7 @@ func initialModel(conns *Connections) *model {
 	m := &model{
 		history:         hist,
 		historyItems:    []historyItem{},
-		tracer:          nil,
+		store:           nil,
 		payloads:        []payloadItem{},
 		topicInput:      ti,
 		messageInput:    ta,
@@ -246,8 +246,8 @@ func initialModel(conns *Connections) *model {
 	}
 	hDel.m = m
 	m.history.SetDelegate(hDel)
-	if idx, err := trace.Open(""); err == nil {
-		m.tracer = idx
+	if idx, err := history.Open(""); err == nil {
+		m.store = idx
 		msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
 		items := make([]list.Item, len(msgs))
 		for i, mmsg := range msgs {

--- a/update_client.go
+++ b/update_client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"goemqutiti/trace"
+	"goemqutiti/history"
 )
 
 func (m *model) handleStatusMessage(msg statusMessage) tea.Cmd {
@@ -287,8 +287,8 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 
 	if m.history.FilterState() == list.Filtering {
 		q := m.history.FilterInput.Value()
-		topics, start, end, text := trace.ParseQuery(q)
-		msgs := m.tracer.Search(topics, start, end, text)
+		topics, start, end, text := history.ParseQuery(q)
+		msgs := m.store.Search(topics, start, end, text)
 		items := make([]list.Item, len(msgs))
 		for i, mmsg := range msgs {
 			items[i] = historyItem{topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind}


### PR DESCRIPTION
## Summary
- rename `trace` package to `history`
- store history per profile using `~/.emqutiti/history/<profile>`
- clarify that topic slashes are allowed in BadgerDB keys

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68865a3174ec832492173d32887c01ed