### PR TITLE
Refactor topics scrolling

### DIFF
--- a/importer/wizard.go
+++ b/importer/wizard.go
@@ -271,7 +271,7 @@ func (w *Wizard) View() string {
 	switch w.step {
 	case stepFile:
 		content := w.file.View() + "\n[enter] load file  [ctrl+n] next"
-		box = ui.LegendBox(content, "Import", bw, 0, ui.ColBlue, true)
+		box = ui.LegendBox(content, "Import", bw, 0, ui.ColBlue, true, -1)
 	case stepMap:
 		colw := 0
 		for _, h := range w.headers {
@@ -288,7 +288,7 @@ func (w *Wizard) View() string {
 			fmt.Fprintf(&b, "%*s : %s\n", colw, label, w.fields[i].View())
 		}
 		b.WriteString("\nUse a.b to nest fields\n[enter] continue  [ctrl+n] next  [ctrl+p] back")
-		box = ui.LegendBox(b.String(), "Map Columns", bw, 0, ui.ColBlue, true)
+		box = ui.LegendBox(b.String(), "Map Columns", bw, 0, ui.ColBlue, true, -1)
 	case stepTemplate:
 		names := make([]string, len(w.headers))
 		for i, h := range w.headers {
@@ -297,7 +297,7 @@ func (w *Wizard) View() string {
 		help := "Available fields: " + strings.Join(names, " ")
 		help = ansi.Wrap(help, wrap, " ")
 		content := w.tmpl.View() + "\n" + help + "\n[enter] continue  [ctrl+n] next  [ctrl+p] back"
-		box = ui.LegendBox(content, "Topic Template", bw, 0, ui.ColBlue, true)
+		box = ui.LegendBox(content, "Topic Template", bw, 0, ui.ColBlue, true, -1)
 	case stepReview:
 		topic := w.tmpl.Value()
 		mapping := w.mapping()
@@ -313,7 +313,7 @@ func (w *Wizard) View() string {
 			previews += ansi.Wrap(line, wrap, " ") + "\n"
 		}
 		s := fmt.Sprintf("Rows: %d\n%s\n[p] publish  [d] dry run  [e] edit  [ctrl+p] back  [q] quit", len(w.rows), previews)
-		box = ui.LegendBox(s, "Review", bw, 0, ui.ColBlue, true)
+		box = ui.LegendBox(s, "Review", bw, 0, ui.ColBlue, true, -1)
 	case stepPublish:
 		bar := w.progress.View()
 		lines := w.published
@@ -339,20 +339,20 @@ func (w *Wizard) View() string {
 		}
 		msg := fmt.Sprintf("%s\n%s\n%s", headerLine, bar, recent)
 		msg = ansi.Wrap(msg, wrap, " ")
-		box = ui.LegendBox(msg, "Progress", bw, 0, ui.ColGreen, true)
+		box = ui.LegendBox(msg, "Progress", bw, 0, ui.ColGreen, true, w.history.ScrollPercent())
 	case stepDone:
 		if w.dryRun {
 			w.history.SetSize(bw, w.historyHeight())
 			w.history.SetLines(spacedLines(w.published))
 			out := w.history.View()
 			out = ansi.Wrap(out, wrap, " ") + "\n[ctrl+p] back  [q] quit"
-			box = ui.LegendBox(out, "Dry Run", bw, 0, ui.ColGreen, true)
+			box = ui.LegendBox(out, "Dry Run", bw, 0, ui.ColGreen, true, w.history.ScrollPercent())
 		} else if w.finished {
 			msg := fmt.Sprintf("Published %d messages\n[ctrl+p] back  [q] quit", len(w.rows))
 			msg = ansi.Wrap(msg, wrap, " ")
-			box = ui.LegendBox(msg, "Import", bw, 0, ui.ColBlue, true)
+			box = ui.LegendBox(msg, "Import", bw, 0, ui.ColBlue, true, -1)
 		} else {
-			box = ui.LegendBox("Done", "Import", bw, 0, ui.ColBlue, true)
+			box = ui.LegendBox("Done", "Import", bw, 0, ui.ColBlue, true, -1)
 		}
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, header, box)

--- a/model.go
+++ b/model.go
@@ -131,12 +131,13 @@ type historyState struct {
 }
 
 type topicsState struct {
-	input      textinput.Model
-	items      []topicItem
-	list       list.Model
-	selected   int
-	chipBounds []chipBound
-	vp         viewport.Model
+	input         textinput.Model
+	items         []topicItem
+	list          list.Model
+	selected      int
+	chipBounds    []chipBound
+	allChipBounds []chipBound
+	vp            viewport.Model
 }
 
 type messageState struct {

--- a/model.go
+++ b/model.go
@@ -131,13 +131,12 @@ type historyState struct {
 }
 
 type topicsState struct {
-	input         textinput.Model
-	items         []topicItem
-	list          list.Model
-	selected      int
-	chipBounds    []chipBound
-	allChipBounds []chipBound
-	vp            viewport.Model
+	input      textinput.Model
+	items      []topicItem
+	list       list.Model
+	selected   int
+	chipBounds []chipBound
+	vp         viewport.Model
 }
 
 type messageState struct {

--- a/model.go
+++ b/model.go
@@ -136,6 +136,7 @@ type topicsState struct {
 	list       list.Model
 	selected   int
 	chipBounds []chipBound
+	vp         viewport.Model
 }
 
 type messageState struct {
@@ -269,6 +270,7 @@ func initialModel(conns *Connections) *model {
 			list:       topicsList,
 			selected:   -1,
 			chipBounds: []chipBound{},
+			vp:         viewport.New(0, 0),
 		},
 		message: messageState{
 			input:    ta,

--- a/topic_scroll_test.go
+++ b/topic_scroll_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"goemqutiti/ui"
+)
+
+func TestTopicsScrollDown(t *testing.T) {
+	m := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	setupManyTopics(m, 10)
+	m.layout.topics.height = 2
+	m.viewClient()
+	if m.topics.vp.YOffset != 0 {
+		t.Fatalf("expected initial scroll 0")
+	}
+	m.setFocus("topics")
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	rowH := lipgloss.Height(ui.ChipStyle.Render("t"))
+	if m.topics.vp.YOffset != rowH {
+		t.Fatalf("expected scroll %d got %d", rowH, m.topics.vp.YOffset)
+	}
+}

--- a/ui/box.go
+++ b/ui/box.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"math"
 	"strings"
 	"unicode"
 
@@ -10,15 +11,15 @@ import (
 // LegendBox renders a bordered box with a label and optional height.
 // The border color can be customized, and when focused the border
 // is highlighted in pink.
-func LegendBox(content, label string, width, height int, border lipgloss.Color, focused bool) string {
+func LegendBox(content, label string, width, height int, border lipgloss.Color, focused bool, scroll float64) string {
 	col := border
 	if focused {
 		col = ColPink
 	}
-	return legendStyledBox(content, label, width, height, col)
+	return legendStyledBox(content, label, width, height, col, scroll)
 }
 
-func legendStyledBox(content, label string, width, height int, color lipgloss.Color) string {
+func legendStyledBox(content, label string, width, height int, color lipgloss.Color, scroll float64) string {
 	content = strings.TrimRight(content, "\n")
 	if width < lipgloss.Width(label)+4 {
 		width = lipgloss.Width(label) + 4
@@ -42,6 +43,18 @@ func legendStyledBox(content, label string, width, height int, color lipgloss.Co
 			lines = append(lines, "")
 		}
 	}
+
+	indicator := -1
+	if scroll >= 0 && height > 0 {
+		indicator = int(math.Round(scroll * float64(height-1)))
+		if indicator < 0 {
+			indicator = 0
+		}
+		if indicator >= height {
+			indicator = height - 1
+		}
+	}
+
 	for i, l := range lines {
 		l = strings.TrimRightFunc(l, unicode.IsSpace)
 		side := color
@@ -49,7 +62,12 @@ func legendStyledBox(content, label string, width, height int, color lipgloss.Co
 			side = cy
 		}
 		left := lipgloss.NewStyle().Foreground(color).Render(b.Left)
-		right := lipgloss.NewStyle().Foreground(side).Render(b.Right)
+		rightChar := string(b.Right)
+		if i == indicator {
+			rightChar = "⧱"
+			side = cy
+		}
+		right := lipgloss.NewStyle().Foreground(side).Render(rightChar)
 		lines[i] = left + lipgloss.PlaceHorizontal(width-2, lipgloss.Left, l) + right
 	}
 	middle := strings.Join(lines, "\n")

--- a/ui/historyview.go
+++ b/ui/historyview.go
@@ -61,6 +61,9 @@ func (h *HistoryView) Update(msg tea.Msg) tea.Cmd {
 // View returns the viewport content.
 func (h HistoryView) View() string { return h.vp.View() }
 
+// ScrollPercent returns the scroll position as a fraction between 0 and 1.
+func (h HistoryView) ScrollPercent() float64 { return h.vp.ScrollPercent() }
+
 // GotoBottom scrolls to the end of the list.
 func (h *HistoryView) GotoBottom() { h.vp.GotoBottom() }
 

--- a/ui/historyview_test.go
+++ b/ui/historyview_test.go
@@ -24,7 +24,7 @@ func TestHistoryViewWidth(t *testing.T) {
 func TestHistoryBoxLayout(t *testing.T) {
 	hv := NewHistoryView(20, 5)
 	hv.SetLines([]string{"foo"})
-	box := LegendBox(hv.View(), "Hist", 20, 0, ColGreen, false)
+	box := LegendBox(hv.View(), "Hist", 20, 0, ColGreen, false, -1)
 	lines := strings.Split(box, "\n")
 	width := lipgloss.Width(lines[0])
 	for i, l := range lines {

--- a/update_client.go
+++ b/update_client.go
@@ -40,6 +40,19 @@ func (m *model) scrollTopics(delta int) {
 	}
 }
 
+func (m *model) ensureTopicVisible() {
+	if m.topics.selected < 0 || m.topics.selected >= len(m.topics.allChipBounds) {
+		return
+	}
+	y := m.topics.allChipBounds[m.topics.selected].y
+	h := m.topics.allChipBounds[m.topics.selected].h
+	if y < m.topics.vp.YOffset {
+		m.topics.vp.SetYOffset(y)
+	} else if y+h > m.topics.vp.YOffset+m.topics.vp.Height {
+		m.topics.vp.SetYOffset(y + h - m.topics.vp.Height)
+	}
+}
+
 func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 	var cmds []tea.Cmd
 	switch msg.String() {
@@ -135,6 +148,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			if id == "topics" {
 				if len(m.topics.items) > 0 {
 					m.topics.selected = 0
+					m.ensureTopicVisible()
 				} else {
 					m.topics.selected = -1
 				}
@@ -143,10 +157,12 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 	case "left":
 		if m.ui.focusOrder[m.ui.focusIndex] == "topics" && len(m.topics.items) > 0 {
 			m.topics.selected = (m.topics.selected - 1 + len(m.topics.items)) % len(m.topics.items)
+			m.ensureTopicVisible()
 		}
 	case "right":
 		if m.ui.focusOrder[m.ui.focusIndex] == "topics" && len(m.topics.items) > 0 {
 			m.topics.selected = (m.topics.selected + 1) % len(m.topics.items)
+			m.ensureTopicVisible()
 		}
 	case "ctrl+shift+up":
 		id := m.ui.focusOrder[m.ui.focusIndex]
@@ -213,6 +229,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		} else if m.ui.focusOrder[m.ui.focusIndex] == "topics" && m.topics.selected >= 0 && m.topics.selected < len(m.topics.items) {
 			m.toggleTopic(m.topics.selected)
+			m.ensureTopicVisible()
 		}
 	case "d":
 		if m.ui.focusOrder[m.ui.focusIndex] == "topics" && m.topics.selected >= 0 && m.topics.selected < len(m.topics.items) {

--- a/update_client.go
+++ b/update_client.go
@@ -41,15 +41,26 @@ func (m *model) scrollTopics(delta int) {
 }
 
 func (m *model) ensureTopicVisible() {
-	if m.topics.selected < 0 || m.topics.selected >= len(m.topics.allChipBounds) {
+	if m.topics.selected < 0 || m.topics.selected >= len(m.topics.items) {
 		return
 	}
-	y := m.topics.allChipBounds[m.topics.selected].y
-	h := m.topics.allChipBounds[m.topics.selected].h
-	if y < m.topics.vp.YOffset {
-		m.topics.vp.SetYOffset(y)
-	} else if y+h > m.topics.vp.YOffset+m.topics.vp.Height {
-		m.topics.vp.SetYOffset(y + h - m.topics.vp.Height)
+	var chips []string
+	for _, t := range m.topics.items {
+		st := ui.ChipStyle
+		if !t.active {
+			st = ui.ChipInactive
+		}
+		chips = append(chips, st.Render(t.title))
+	}
+	_, bounds := layoutChips(chips, m.ui.width-4)
+	if m.topics.selected >= len(bounds) {
+		return
+	}
+	b := bounds[m.topics.selected]
+	if b.y < m.topics.vp.YOffset {
+		m.topics.vp.SetYOffset(b.y)
+	} else if b.y+b.h > m.topics.vp.YOffset+m.topics.vp.Height {
+		m.topics.vp.SetYOffset(b.y + b.h - m.topics.vp.Height)
 	}
 }
 

--- a/views.go
+++ b/views.go
@@ -86,7 +86,6 @@ func (m *model) viewClient() string {
 	m.topics.vp.Width = m.ui.width - 4
 	m.topics.vp.Height = topicsBoxHeight
 	m.topics.vp.SetContent(strings.Join(chipRows, "\n"))
-	m.topics.allChipBounds = bounds
 	m.ensureTopicVisible()
 	startLine := m.topics.vp.YOffset
 	endLine := startLine + topicsBoxHeight

--- a/views.go
+++ b/views.go
@@ -10,7 +10,7 @@ import (
 	"goemqutiti/ui"
 )
 
-func layoutChips(chips []string, width int) (string, []chipBound) {
+func layoutChips(chips []string, width int) ([]string, []chipBound) {
 	var lines []string
 	var row []string
 	var bounds []chipBound
@@ -40,7 +40,7 @@ func layoutChips(chips []string, width int) (string, []chipBound) {
 		line = strings.TrimRightFunc(line, unicode.IsSpace)
 		lines = append(lines, line)
 	}
-	return strings.Join(lines, "\n"), bounds
+	return lines, bounds
 }
 
 func (m *model) viewClient() string {
@@ -76,20 +76,27 @@ func (m *model) viewClient() string {
 	messageFocused := m.ui.focusOrder[m.ui.focusIndex] == "message"
 	historyFocused := m.ui.focusOrder[m.ui.focusIndex] == "history"
 
-	chipContent, bounds := layoutChips(chips, m.ui.width-4)
+	chipRows, bounds := layoutChips(chips, m.ui.width-4)
 	rowH := lipgloss.Height(ui.ChipStyle.Render("test"))
 	maxRows := m.layout.topics.height
 	if maxRows <= 0 {
 		maxRows = 3
 	}
-	lines := strings.Split(chipContent, "\n")
-	limit := maxRows * rowH
-	if len(lines) > limit {
-		chipContent = strings.Join(lines[:limit], "\n")
+	topicsBoxHeight := maxRows * rowH
+	m.topics.vp.Width = m.ui.width - 4
+	m.topics.vp.Height = topicsBoxHeight
+	m.topics.vp.SetContent(strings.Join(chipRows, "\n"))
+	startLine := m.topics.vp.YOffset
+	endLine := startLine + topicsBoxHeight
+	topicsSP := -1.0
+	if len(chipRows)*rowH > topicsBoxHeight {
+		topicsSP = m.topics.vp.ScrollPercent()
 	}
+	chipContent := m.topics.vp.View()
 	visible := []chipBound{}
 	for _, b := range bounds {
-		if b.y/rowH < maxRows {
+		if b.y >= startLine && b.y < endLine {
+			b.y -= startLine
 			visible = append(visible, b)
 		}
 	}
@@ -101,11 +108,38 @@ func (m *model) viewClient() string {
 		}
 	}
 	label := fmt.Sprintf("Topics %d/%d", active, len(m.topics.items))
-	topicsBoxHeight := maxRows * rowH
-	topicsBox := ui.LegendBox(chipContent, label, m.ui.width-2, topicsBoxHeight, ui.ColBlue, topicsFocused)
-	topicBox := ui.LegendBox(m.topics.input.View(), "Topic", m.ui.width-2, 0, ui.ColBlue, topicFocused)
-	messageBox := ui.LegendBox(m.message.input.View(), "Message (Ctrl+S publishes)", m.ui.width-2, m.layout.message.height, ui.ColBlue, messageFocused)
-	messagesBox := ui.LegendBox(m.history.list.View(), "History (Ctrl+C copy)", m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused)
+	topicsBox := ui.LegendBox(chipContent, label, m.ui.width-2, topicsBoxHeight, ui.ColBlue, topicsFocused, topicsSP)
+	topicBox := ui.LegendBox(m.topics.input.View(), "Topic", m.ui.width-2, 0, ui.ColBlue, topicFocused, -1)
+	msgContent := m.message.input.View()
+	msgLines := m.message.input.LineCount()
+	msgHeight := m.layout.message.height
+	msgSP := -1.0
+	if msgLines > msgHeight {
+		off := m.message.input.Line() - msgHeight + 1
+		if off < 0 {
+			off = 0
+		}
+		maxOff := msgLines - msgHeight
+		if off > maxOff {
+			off = maxOff
+		}
+		if maxOff > 0 {
+			msgSP = float64(off) / float64(maxOff)
+		}
+	}
+	messageBox := ui.LegendBox(msgContent, "Message (Ctrl+S publishes)", m.ui.width-2, msgHeight, ui.ColBlue, messageFocused, msgSP)
+	// Calculate scroll percent for the history list
+	per := m.history.list.Paginator.PerPage
+	total := len(m.history.list.Items())
+	histSP := -1.0
+	if total > per {
+		start := m.history.list.Paginator.Page * per
+		denom := total - per
+		if denom > 0 {
+			histSP = float64(start) / float64(denom)
+		}
+	}
+	messagesBox := ui.LegendBox(m.history.list.View(), "History (Ctrl+C copy)", m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused, histSP)
 
 	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)
 
@@ -130,26 +164,28 @@ func (m *model) viewClient() string {
 	m.ui.viewport.Width = m.ui.width
 	// Deduct two lines for the info header rendered above the viewport.
 	m.ui.viewport.Height = m.ui.height - 2
-	return lipgloss.JoinVertical(lipgloss.Left, infoLine, m.ui.viewport.View())
+
+	view := m.ui.viewport.View()
+	return lipgloss.JoinVertical(lipgloss.Left, infoLine, view)
 }
 
 func (m model) viewConnections() string {
 	listView := m.connections.manager.ConnectionsList.View()
 	help := ui.InfoStyle.Render("[enter] connect/open client  [x] disconnect  [a]dd [e]dit [d]elete")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return ui.LegendBox(content, "Brokers", m.ui.width-2, 0, ui.ColBlue, true)
+	return ui.LegendBox(content, "Brokers", m.ui.width-2, 0, ui.ColBlue, true, -1)
 }
 
 func (m model) viewForm() string {
 	if m.connections.form == nil {
 		return ""
 	}
-	listView := ui.LegendBox(m.connections.manager.ConnectionsList.View(), "Brokers", m.ui.width/2-2, 0, ui.ColBlue, false)
+	listView := ui.LegendBox(m.connections.manager.ConnectionsList.View(), "Brokers", m.ui.width/2-2, 0, ui.ColBlue, false, -1)
 	formLabel := "Add Broker"
 	if m.connections.form.index >= 0 {
 		formLabel = "Edit Broker"
 	}
-	formView := ui.LegendBox(m.connections.form.View(), formLabel, m.ui.width/2-2, 0, ui.ColBlue, true)
+	formView := ui.LegendBox(m.connections.form.View(), formLabel, m.ui.width/2-2, 0, ui.ColBlue, true, -1)
 	return lipgloss.JoinHorizontal(lipgloss.Top, listView, formView)
 }
 
@@ -162,14 +198,14 @@ func (m model) viewTopics() string {
 	listView := m.topics.list.View()
 	help := ui.InfoStyle.Render("[space] toggle  [d]elete  [esc] back")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return ui.LegendBox(content, "Topics", m.ui.width-2, 0, ui.ColBlue, false)
+	return ui.LegendBox(content, "Topics", m.ui.width-2, 0, ui.ColBlue, false, -1)
 }
 
 func (m model) viewPayloads() string {
 	listView := m.message.list.View()
 	help := ui.InfoStyle.Render("[enter] load  [d]elete  [esc] back")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return ui.LegendBox(content, "Payloads", m.ui.width-2, 0, ui.ColBlue, false)
+	return ui.LegendBox(content, "Payloads", m.ui.width-2, 0, ui.ColBlue, false, -1)
 }
 
 func (m *model) View() string {

--- a/views.go
+++ b/views.go
@@ -86,6 +86,8 @@ func (m *model) viewClient() string {
 	m.topics.vp.Width = m.ui.width - 4
 	m.topics.vp.Height = topicsBoxHeight
 	m.topics.vp.SetContent(strings.Join(chipRows, "\n"))
+	m.topics.allChipBounds = bounds
+	m.ensureTopicVisible()
 	startLine := m.topics.vp.YOffset
 	endLine := startLine + topicsBoxHeight
 	topicsSP := -1.0


### PR DESCRIPTION
## Summary
- use a viewport to manage scrolling for topics
- compute chip indicator from viewport scroll percent
- update tests to check viewport offset

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887452cbc688324acfda2fad4a6789e