### PR TITLE
Add flag aliases and update documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Run `go vet ./...` and attempt `go test ./...` before committing.
 
 ## Agent Notes
-The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused. Use the `-import` flag to launch an interactive wizard for CSV or XLS bulk publishing. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name.
+The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name.
 Press `Ctrl+D` from any screen to exit the program.
 
 ### Recent Experience

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ All `Ctrl` shortcuts are global, so they work even when an input field is active
 
 ### Importing from CSV or XLS
 
-Run the program with `-import` to launch an interactive wizard that guides you
+Run the program with `--import` (or `-i`) to launch an interactive wizard that guides you
 through selecting a file, mapping column names, defining the topic template and
 publishing the messages. During the mapping step each CSV column appears on the
 left with an editable field on the right so you can rename it for the JSON
@@ -109,7 +109,7 @@ payload. Leaving a mapping blank keeps the original column name. Providing a
 path pre-selects the file in the wizard:
 
 ```bash
-./goemqutiti -import data.csv -profile local
+./goemqutiti -i data.csv -p local
 ```
 
 Each row becomes a JSON object with properties derived from the mapped column

--- a/main.go
+++ b/main.go
@@ -48,9 +48,16 @@ import (
 // }
 
 var (
-	importFile  = flag.String("import", "", "Launch import wizard with optional file path")
-	profileName = flag.String("profile", "", "Connection profile to use")
+	importFile  string
+	profileName string
 )
+
+func init() {
+	flag.StringVar(&importFile, "import", "", "Launch import wizard with optional file path")
+	flag.StringVar(&importFile, "i", "", "(shorthand)")
+	flag.StringVar(&profileName, "profile", "", "Connection profile to use")
+	flag.StringVar(&profileName, "p", "", "(shorthand)")
+}
 
 func main() {
 	flag.Parse()
@@ -64,8 +71,8 @@ func main() {
 	// Set log output to file
 	log.SetOutput(logFile)
 
-	if *importFile != "" {
-		runImport(*importFile, *profileName)
+	if importFile != "" {
+		runImport(importFile, profileName)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- register both long and short flags for `import` and `profile`
- update README to mention `--import`/`-i` and `--profile`/`-p`
- revise AGENTS instructions accordingly

## Testing
- `gofmt -w main.go`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68876b650a94832492bdf9d0c1ad6d08