### PR TITLE
Add separate Badger DB for traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ In the interface:
   and free text to match payloads. Example:
   `topic=sensors/start start=2024-01-01T00:00:00Z payload=error`.
   The history log is stored in BadgerDB under
-  `~/.emqutiti/history/<profile>` so messages remain searchable per profile.
+  `~/.emqutiti/data/<profile>/history` so messages remain searchable per profile.
+  Any traces recorded with the tracer package are saved separately in
+  `~/.emqutiti/data/<profile>/traces`.
 - **Esc** navigates back within menus without quitting.
 - **Ctrl+D** exits the program.
 - Left-click a topic chip to toggle it and middle-click to remove it.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1,0 +1,173 @@
+package tracer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"goemqutiti/history"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// Config defines the trace parameters.
+type Config struct {
+	Profile string
+	Topics  []string
+	Start   time.Time
+	End     time.Time
+	Key     string
+}
+
+// Client abstracts the MQTT client used by the tracer.
+type Client interface {
+	Subscribe(topic string, qos byte, cb mqtt.MessageHandler) error
+	Unsubscribe(topic string) error
+	Disconnect()
+}
+
+// Tracer collects MQTT messages within a time range and stores them.
+type Tracer struct {
+	cfg     Config
+	mu      sync.Mutex
+	running bool
+	counts  map[string]int
+	client  Client
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// New creates a new Tracer with the given config.
+func New(cfg Config, c Client) *Tracer {
+	return &Tracer{cfg: cfg, client: c}
+}
+
+// Start begins the trace.
+func (t *Tracer) Start() error {
+	t.mu.Lock()
+	if t.running {
+		t.mu.Unlock()
+		return fmt.Errorf("trace already running")
+	}
+	t.running = true
+	t.counts = make(map[string]int)
+	t.mu.Unlock()
+
+	idx, err := history.OpenTrace(t.cfg.Profile)
+	if err != nil {
+		return err
+	}
+
+	client := t.client
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
+	t.done = make(chan struct{})
+
+	go func() {
+		defer func() {
+			client.Disconnect()
+			idx.Close()
+			cancel()
+			t.mu.Lock()
+			t.running = false
+			t.cancel = nil
+			t.mu.Unlock()
+			close(t.done)
+		}()
+
+		delay := time.Until(t.cfg.Start)
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		endCh := make(<-chan time.Time)
+		if !t.cfg.End.IsZero() {
+			if d := time.Until(t.cfg.End); d > 0 {
+				timer := time.NewTimer(d)
+				endCh = timer.C
+			}
+		}
+
+		for _, topic := range t.cfg.Topics {
+			client.Subscribe(topic, 0, func(_ mqtt.Client, m mqtt.Message) {
+				ts := time.Now()
+				if !t.cfg.End.IsZero() && ts.After(t.cfg.End) {
+					return
+				}
+				if ts.Before(t.cfg.Start) {
+					return
+				}
+				idx.AddTrace(t.cfg.Key, history.Message{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"})
+				t.mu.Lock()
+				t.counts[m.Topic()]++
+				t.mu.Unlock()
+			})
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-endCh:
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop terminates the trace.
+func (t *Tracer) Stop() {
+	t.mu.Lock()
+	if !t.running {
+		t.mu.Unlock()
+		return
+	}
+	t.running = false
+	if t.cancel != nil {
+		t.cancel()
+	}
+	done := t.done
+	t.mu.Unlock()
+	if done != nil {
+		<-done
+	}
+}
+
+// Running reports whether the trace is currently active.
+func (t *Tracer) Running() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.running && time.Now().After(t.cfg.Start) && (t.cfg.End.IsZero() || time.Now().Before(t.cfg.End))
+}
+
+// Planned reports whether the trace start time is in the future.
+func (t *Tracer) Planned() bool { return time.Now().Before(t.cfg.Start) }
+
+// Counts returns the per-topic message counts.
+func (t *Tracer) Counts() map[string]int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make(map[string]int, len(t.counts))
+	for k, v := range t.counts {
+		out[k] = v
+	}
+	return out
+}
+
+// Messages returns the stored trace messages.
+func (t *Tracer) Messages() ([]history.Message, error) {
+	idx, err := history.OpenTrace(t.cfg.Profile)
+	if err != nil {
+		return nil, err
+	}
+	defer idx.Close()
+	return idx.TraceMessages(t.cfg.Key)
+}

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -1,0 +1,87 @@
+package tracer
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"goemqutiti/history"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+type fakeMessage struct {
+	topic   string
+	payload []byte
+}
+
+func (f fakeMessage) Duplicate() bool   { return false }
+func (f fakeMessage) Qos() byte         { return 0 }
+func (f fakeMessage) Retained() bool    { return false }
+func (f fakeMessage) Topic() string     { return f.topic }
+func (f fakeMessage) MessageID() uint16 { return 0 }
+func (f fakeMessage) Payload() []byte   { return f.payload }
+func (f fakeMessage) Ack()              {}
+
+type fakeClient struct {
+	subs map[string]mqtt.MessageHandler
+}
+
+func newFakeClient() *fakeClient { return &fakeClient{subs: make(map[string]mqtt.MessageHandler)} }
+
+func (f *fakeClient) Subscribe(topic string, qos byte, cb mqtt.MessageHandler) error {
+	f.subs[topic] = cb
+	return nil
+}
+func (f *fakeClient) Unsubscribe(topic string) error { delete(f.subs, topic); return nil }
+func (f *fakeClient) Disconnect()                    {}
+
+func (f *fakeClient) publish(topic, payload string) {
+	if cb, ok := f.subs[topic]; ok {
+		cb(nil, fakeMessage{topic: topic, payload: []byte(payload)})
+	}
+}
+
+func TestTraceStartAndStore(t *testing.T) {
+	dir := t.TempDir()
+	os.Setenv("HOME", dir)
+
+	cfg := Config{
+		Profile: "test",
+		Topics:  []string{"a"},
+		Start:   time.Now().Add(-time.Millisecond),
+		End:     time.Now().Add(200 * time.Millisecond),
+		Key:     "k1",
+	}
+	fc := newFakeClient()
+	tr := New(cfg, fc)
+	if err := tr.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	fc.publish("a", "one")
+	fc.publish("a", "two")
+	time.Sleep(20 * time.Millisecond)
+	tr.Stop()
+	time.Sleep(5 * time.Millisecond)
+
+	idx, err := history.OpenTrace("test")
+	if err != nil {
+		t.Fatalf("open history: %v", err)
+	}
+	keys, err := idx.TraceKeys("k1")
+	if err != nil {
+		t.Fatalf("trace keys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	prefix := "trace/k1/a/"
+	for _, k := range keys {
+		if !strings.HasPrefix(k, prefix) {
+			t.Fatalf("bad key %s", k)
+		}
+	}
+	idx.Close()
+}


### PR DESCRIPTION
## Summary
- move traces into their own database under `~/.emqutiti/data/<profile>`
- expose `OpenTrace` helper in history package
- update tracer to use the trace database
- document new directory layout

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68876ce23da8832496c36b02219c8ab4