### PR TITLE
Export shared EnvPrefix helper

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -91,14 +91,16 @@ func sanitizeEnvName(name string) string {
 	return b.String()
 }
 
-func envPrefix(name string) string { return "GOEMQUTITI_" + sanitizeEnvName(name) + "_" }
+// EnvPrefix returns the prefix used for environment variables derived from a
+// profile name.
+func EnvPrefix(name string) string { return "GOEMQUTITI_" + sanitizeEnvName(name) + "_" }
 
 // ApplyEnvVars loads profile fields from environment variables when FromEnv is set.
 func ApplyEnvVars(p *Profile) {
 	if !p.FromEnv {
 		return
 	}
-	prefix := envPrefix(p.Name)
+	prefix := EnvPrefix(p.Name)
 	rv := reflect.ValueOf(p).Elem()
 	rt := rv.Type()
 	for i := 0; i < rt.NumField(); i++ {

--- a/connectionform.go
+++ b/connectionform.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,19 +9,6 @@ import (
 	"github.com/marang/goemqutiti/config"
 	"github.com/marang/goemqutiti/ui"
 )
-
-func envPrefix(name string) string {
-	upper := strings.ToUpper(name)
-	var b strings.Builder
-	for _, r := range upper {
-		if r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
-			b.WriteRune(r)
-		} else {
-			b.WriteRune('_')
-		}
-	}
-	return "GOEMQUTITI_" + b.String() + "_"
-}
 
 type formField interface {
 	Focus()
@@ -434,7 +420,7 @@ func (f connectionForm) View() string {
 		s += fmt.Sprintf("%s: %s\n", label, in.View())
 	}
 	if chk, ok := f.fields[idxFromEnv].(*checkField); ok && chk.value {
-		prefix := envPrefix(f.fields[idxName].Value())
+		prefix := config.EnvPrefix(f.fields[idxName].Value())
 		s += ui.InfoStyle.Render("Values loaded from env vars: "+prefix+"<FIELD>") + "\n"
 	}
 	s += "\n" + ui.InfoStyle.Render("[enter] save  [esc] cancel")


### PR DESCRIPTION
## Summary
- export `EnvPrefix` from the config package
- remove duplicate helper in `connectionform.go`
- reference the shared helper when showing env info

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68881096d4c48324b9639c855a4ed91a