### PR TITLE
Flatten history DB helper into main package

### DIFF
--- a/model.go
+++ b/model.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/marang/goemqutiti/history"
 	"github.com/marang/goemqutiti/ui"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -130,7 +129,7 @@ type connectionsState struct {
 type historyState struct {
 	list            list.Model
 	items           []historyItem
-	store           *history.Index
+	store           *HistoryStore
 	selected        map[int]struct{}
 	selectionAnchor int
 }

--- a/model_init.go
+++ b/model_init.go
@@ -12,7 +12,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/marang/goemqutiti/history"
 	"github.com/marang/goemqutiti/ui"
 )
 
@@ -170,7 +169,7 @@ func initialModel(conns *Connections) *model {
 	m.history.list.SetDelegate(hDel)
 	traceDel.m = m
 	m.traces.view.SetDelegate(traceDel)
-	if idx, err := history.Open(""); err == nil {
+	if idx, err := openHistoryStore(""); err == nil {
 		m.history.store = idx
 		msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
 		items := make([]list.Item, len(msgs))

--- a/tracedelegate.go
+++ b/tracedelegate.go
@@ -10,14 +10,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
-	"github.com/marang/goemqutiti/history"
+	"github.com/marang/goemqutiti/tracer"
 	"github.com/marang/goemqutiti/ui"
 )
 
 // traceMsgItem holds a trace message with its sequence number.
 type traceMsgItem struct {
 	idx int
-	msg history.Message
+	msg tracer.Message
 }
 
 func (t traceMsgItem) FilterValue() string { return t.msg.Payload }

--- a/tracer/message.go
+++ b/tracer/message.go
@@ -1,0 +1,11 @@
+package tracer
+
+import "time"
+
+// Message holds a timestamped MQTT message used for traces.
+type Message struct {
+	Timestamp time.Time
+	Topic     string
+	Payload   string
+	Kind      string
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/marang/goemqutiti/history"
-
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
@@ -100,7 +98,7 @@ func (t *Tracer) Start() error {
 				if ts.Before(t.cfg.Start) {
 					return
 				}
-				Add(t.cfg.Profile, t.cfg.Key, history.Message{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"})
+				Add(t.cfg.Profile, t.cfg.Key, Message{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"})
 				t.mu.Lock()
 				for _, sub := range t.cfg.Topics {
 					if Match(sub, m.Topic()) {
@@ -167,6 +165,6 @@ func (t *Tracer) Counts() map[string]int {
 }
 
 // Messages returns the stored trace messages.
-func (t *Tracer) Messages() ([]history.Message, error) {
+func (t *Tracer) Messages() ([]Message, error) {
 	return Messages(t.cfg.Profile, t.cfg.Key)
 }

--- a/update.go
+++ b/update.go
@@ -9,7 +9,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/marang/goemqutiti/config"
-	"github.com/marang/goemqutiti/history"
 )
 
 type statusMessage string
@@ -103,7 +102,7 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 	m.history.list.SetItems(items)
 	m.history.list.Select(len(items) - 1)
 	if m.history.store != nil {
-		m.history.store.Add(history.Message{Timestamp: time.Now(), Topic: topic, Payload: payload, Kind: kind})
+		m.history.store.Add(Message{Timestamp: time.Now(), Topic: topic, Payload: payload, Kind: kind})
 	}
 }
 
@@ -188,7 +187,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			if m.history.store != nil {
 				m.history.store.Close()
 			}
-			if idx, err := history.Open(msg.profile.Name); err == nil {
+			if idx, err := openHistoryStore(msg.profile.Name); err == nil {
 				m.history.store = idx
 				msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
 				m.history.items = nil

--- a/update_client.go
+++ b/update_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/marang/goemqutiti/history"
 	"github.com/marang/goemqutiti/ui"
 )
 
@@ -407,7 +406,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 
 	if m.history.list.FilterState() == list.Filtering {
 		q := m.history.list.FilterInput.Value()
-		topics, start, end, text := history.ParseQuery(q)
+		topics, start, end, text := parseHistoryQuery(q)
 		msgs := m.history.store.Search(topics, start, end, text)
 		items := make([]list.Item, len(msgs))
 		for i, mmsg := range msgs {


### PR DESCRIPTION
## Summary
- move `history/history.go` to root and rename to `historystore.go`
- adjust code to use new `HistoryStore` type and helper names
- add local trace `Message` struct and storage paths
- update imports and references across project

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688808a3e8dc8324ba825b0c3b367816