### PR TITLE
Flatten importer package

### DIFF
--- a/importer_reader.go
+++ b/importer_reader.go
@@ -1,4 +1,4 @@
-package importer
+package main
 
 import (
 	"encoding/csv"

--- a/importer_reader_test.go
+++ b/importer_reader_test.go
@@ -1,4 +1,4 @@
-package importer
+package main
 
 import (
 	"encoding/json"

--- a/importer_wizard.go
+++ b/importer_wizard.go
@@ -1,4 +1,4 @@
-package importer
+package main
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/marang/goemqutiti/config"
-	"github.com/marang/goemqutiti/importer"
 	"github.com/marang/goemqutiti/tracer"
 )
 
@@ -174,7 +173,7 @@ func runImport(path, profile string) {
 	}
 	defer client.Disconnect()
 
-	w := importer.NewWizard(client, path)
+	w := NewWizard(client, path)
 	prog := tea.NewProgram(w, tea.WithAltScreen())
 	if _, err := prog.Run(); err != nil {
 		fmt.Println("import error:", err)


### PR DESCRIPTION
## Summary
- move importer source files to repo root
- rename importer files with `importer_` prefix
- update to `package main`
- adjust imports and references

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68881c35ae008324a3d654ba6aca3603