### PR TITLE
Update importer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Run `go vet ./...` and attempt `go test ./...` before committing.
 
 ## Agent Notes
-The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name.
+The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name. The importer code lives in the main package and runs via these flags.
 Press `Ctrl+D` from any screen to exit the program.
 
 ### Recent Experience

--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ All `Ctrl` shortcuts are global, so they work even when an input field is active
 
 ### Importing from CSV or XLS
 
-Run the program with `--import` (or `-i`) to launch an interactive wizard that guides you
-through selecting a file, mapping column names, defining the topic template and
-publishing the messages. During the mapping step each CSV column appears on the
-left with an editable field on the right so you can rename it for the JSON
-payload. Leaving a mapping blank keeps the original column name. Providing a
-path pre-selects the file in the wizard:
+The importer now lives in the main package, so use the same `emqutiti` binary to
+launch it. Run the program with `--import` (or `-i`) to start an interactive
+wizard that guides you through selecting a file, mapping column names, defining
+the topic template and publishing the messages. During the mapping step each CSV
+column appears on the left with an editable field on the right so you can rename
+it for the JSON payload. Leaving a mapping blank keeps the original column name.
+Providing a path pre-selects the file in the wizard:
 
 ```bash
 ./emqutiti -i data.csv -p local

--- a/TODO.md
+++ b/TODO.md
@@ -80,4 +80,5 @@ This document tracks the tasks and goals for developing the GoEmqutiti MQTT clie
 - Regularly update this TODO list as tasks are completed or new requirements emerge.
 - Keep the documentation in `README.md`, `TODO.md`, and `AGENTS.md` aligned with the current implementation.
 - Ensure `Ctrl+D` quits the TUI from every screen.
+- The importer code is part of the main package and runs via the `--import`/`-i` flag.
 


### PR DESCRIPTION
## Summary
- clarify importer flag usage in README
- note that importer code lives in main package

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68881c39b61c83249f022c3e3083967a