### PR TITLE
Add data cleanup and center confirm dialog

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -134,9 +135,16 @@ func (m *Connections) DeleteConnection(index int) {
 		m.Profiles = append(m.Profiles[:index], m.Profiles[index+1:]...)
 		delete(m.Statuses, name)
 		delete(m.Errors, name)
+		// Persist removal so the connection no longer appears after a restart
 		m.saveConfigToFile()
+		deleteProfileData(name)
 		m.refreshList()
 	}
+}
+
+func deleteProfileData(name string) {
+	os.RemoveAll(historyDir(name))
+	os.RemoveAll(tracerDataDir(name))
 }
 
 // refreshList rebuilds the list items from the current profiles.

--- a/model.go
+++ b/model.go
@@ -233,6 +233,7 @@ type model struct {
 	ui uiState
 
 	confirmPrompt string
+	confirmInfo   string
 	confirmAction func()
 
 	layout layoutConfig

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -26,8 +26,9 @@ func (m *model) historyIndexAt(y int) int {
 	return i
 }
 
-func (m *model) startConfirm(prompt string, action func()) {
+func (m *model) startConfirm(prompt, info string, action func()) {
 	m.confirmPrompt = prompt
+	m.confirmInfo = info
 	m.confirmAction = action
 	m.ui.prevMode = m.ui.mode
 	m.ui.mode = modeConfirmDelete

--- a/model_traces.go
+++ b/model_traces.go
@@ -48,7 +48,7 @@ func (m *model) startTrace(index int) {
 	}
 	exists, err := tracerHasData(item.cfg.Profile, item.key)
 	if err == nil && exists {
-		m.startConfirm(fmt.Sprintf("Overwrite trace '%s'? [y/n]", item.key), func() {
+		m.startConfirm(fmt.Sprintf("Overwrite trace '%s'? [y/n]", item.key), "existing trace data will be removed", func() {
 			tracerClearData(item.cfg.Profile, item.key)
 			m.forceStartTrace(index)
 		})

--- a/update.go
+++ b/update.go
@@ -277,7 +277,8 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			i := m.connections.manager.ConnectionsList.Index()
 			if i >= 0 {
 				name := m.connections.manager.Profiles[i].Name
-				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), func() {
+				info := "This also deletes history and traces"
+				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), info, func() {
 					m.connections.manager.DeleteConnection(i)
 					m.connections.manager.refreshList()
 					m.refreshConnectionItems()
@@ -369,7 +370,7 @@ func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
 			i := m.topics.list.Index()
 			if i >= 0 && i < len(m.topics.items) {
 				name := m.topics.items[i].title
-				m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), func() {
+				m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() {
 					m.removeTopic(i)
 					items := []list.Item{}
 					for _, t := range m.topics.items {

--- a/update_client.go
+++ b/update_client.go
@@ -246,7 +246,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 		if m.ui.focusOrder[m.ui.focusIndex] == "topics" && m.topics.selected >= 0 && m.topics.selected < len(m.topics.items) {
 			idx := m.topics.selected
 			name := m.topics.items[idx].title
-			m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), func() {
+			m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() {
 				m.removeTopic(idx)
 			})
 		}
@@ -347,7 +347,7 @@ func (m *model) handleTopicsClick(msg tea.MouseMsg) {
 		m.toggleTopic(idx)
 	} else if msg.Type == tea.MouseRight {
 		name := m.topics.items[idx].title
-		m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), func() {
+		m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() {
 			m.removeTopic(idx)
 		})
 	}

--- a/views.go
+++ b/views.go
@@ -191,8 +191,12 @@ func (m model) viewForm() string {
 }
 
 func (m model) viewConfirmDelete() string {
-	border := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(ui.ColBlue).Padding(0, 1)
-	return border.Render(m.confirmPrompt)
+	content := m.confirmPrompt
+	if m.confirmInfo != "" {
+		content = lipgloss.JoinVertical(lipgloss.Left, m.confirmPrompt, m.confirmInfo)
+	}
+	box := ui.LegendBox(content, "Confirm", m.ui.width/2, 0, ui.ColBlue, true, -1)
+	return lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 func (m model) viewTopics() string {


### PR DESCRIPTION
## Summary
- improve confirmation dialog by allowing extra info and centering the legend box
- ask users to confirm that broker deletion will remove all stored history and traces
- remove data directories when a connection is deleted
- clarify why the config is saved when deleting a connection

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68887b6906e483249cc136c2d1356721