### PR TITLE
Fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go install github.com/marang/goemqutiti@latest
 ```
 
 Clone and `go build` if you prefer working from source. Arch users can simply
-install it from the AUR using `pacman -S goemqutiti` (or your favorite helper).
+install it from the AUR using `pacman -S emqutiti` (or your favorite helper).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- correct the AUR installation command to use the `emqutiti` package

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68888403434883248957b91bfb74953a