### PR TITLE
Log clipboard errors

### DIFF
--- a/update_client.go
+++ b/update_client.go
@@ -89,7 +89,9 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 					parts = append(parts, txt)
 				}
 			}
-			clipboard.WriteAll(strings.Join(parts, "\n"))
+			if err := clipboard.WriteAll(strings.Join(parts, "\n")); err != nil {
+				m.appendHistory("", err.Error(), "log", err.Error())
+			}
 		} else if len(m.history.list.Items()) > 0 {
 			idx := m.history.list.Index()
 			if idx >= 0 {
@@ -98,7 +100,9 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 				if hi.kind != "log" {
 					text = fmt.Sprintf("%s: %s", hi.topic, hi.payload)
 				}
-				clipboard.WriteAll(text)
+				if err := clipboard.WriteAll(text); err != nil {
+					m.appendHistory("", err.Error(), "log", err.Error())
+				}
 			}
 		}
 	case "ctrl+x":


### PR DESCRIPTION
## Summary
- handle errors when copying messages to the clipboard
- add failures to history so they show up in the UI

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888840cf41883249c8630be7750c48b