### PR TITLE
Enable help open via Enter or Space

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that pressing enter with the help icon focused opens the help view.
+func TestEnterOpensHelp(t *testing.T) {
+	m := initialModel(nil)
+	m.setFocus("help")
+	if m.ui.focusOrder[m.ui.focusIndex] != "help" {
+		t.Fatalf("help not focused")
+	}
+	if m.ui.mode != modeClient {
+		t.Fatalf("initial mode not client: %v", m.ui.mode)
+	}
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("expected nil command")
+	}
+	if m.ui.mode != modeHelp {
+		t.Fatalf("expected help mode, got %v", m.ui.mode)
+	}
+}
+
+// Test that space also opens help when focused.
+func TestSpaceOpensHelp(t *testing.T) {
+	m := initialModel(nil)
+	m.setFocus("help")
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if cmd != nil {
+		t.Fatalf("expected nil command")
+	}
+	if m.ui.mode != modeHelp {
+		t.Fatalf("expected help mode, got %v", m.ui.mode)
+	}
+}

--- a/update.go
+++ b/update.go
@@ -493,6 +493,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reserve two lines for the info header at the top of the view.
 		m.ui.viewport.Height = msg.Height - 2
 		return m, nil
+	case tea.KeyMsg:
+		if (msg.String() == "enter" || msg.String() == " " || msg.String() == "space") &&
+			m.ui.focusOrder[m.ui.focusIndex] == "help" {
+			m.ui.prevMode = m.ui.mode
+			m.ui.mode = modeHelp
+			return m, nil
+		}
 	}
 
 	switch m.ui.mode {


### PR DESCRIPTION
## Summary
- switch to help mode when the help element is focused and Enter or Space is pressed
- add tests for opening help using Enter or Space

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a3c874a108324bf891af45f766fff