### PR TITLE
Fix topics list refresh after toggling

### DIFF
--- a/update.go
+++ b/update.go
@@ -400,9 +400,14 @@ func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
 			i := m.topics.list.Index()
 			if i >= 0 && i < len(m.topics.items) {
 				m.toggleTopic(i)
-				items := m.topics.list.Items()
-				items[i] = m.topics.items[i]
+				// Rebuild the list after sorting to keep
+				// indices in sync with the underlying data.
+				items := make([]list.Item, len(m.topics.items))
+				for j, t := range m.topics.items {
+					items[j] = t
+				}
 				m.topics.list.SetItems(items)
+				m.topics.list.Select(m.topics.selected)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- refresh the topic manager list after toggling a topic

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a7efed3e48324a32f5aae2cd5f3c3