### PR TITLE
Fix confirm view and topic focus

### DIFF
--- a/model.go
+++ b/model.go
@@ -33,7 +33,7 @@ var focusByMode = map[appMode][]string{
 	modeClient:         {idTopics, idTopic, idMessage, idHistory, idHelp},
 	modeConnections:    {idConnList, idHelp},
 	modeEditConnection: {idConnList, idHelp},
-	modeConfirmDelete:  {idHelp},
+	modeConfirmDelete:  {},
 	modeTopics:         {idTopicList, idHelp},
 	modePayloads:       {idPayloadList, idHelp},
 	modeTracer:         {idTraceList, idHelp},

--- a/update.go
+++ b/update.go
@@ -400,9 +400,15 @@ func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
 			i := m.topics.list.Index()
 			if i >= 0 && i < len(m.topics.items) {
 				m.toggleTopic(i)
-				items := m.topics.list.Items()
-				items[i] = m.topics.items[i]
+				// Rebuild the list after sorting to keep
+				// indices in sync with the underlying data.
+				items := make([]list.Item, len(m.topics.items))
+				for j, t := range m.topics.items {
+					items[j] = t
+				}
+				m.topics.selected = i
 				m.topics.list.SetItems(items)
+				m.topics.list.Select(i)
 			}
 		}
 	}

--- a/views.go
+++ b/views.go
@@ -226,7 +226,7 @@ func (m model) viewConfirmDelete() string {
 		content = lipgloss.JoinVertical(lipgloss.Left, m.confirmPrompt, m.confirmInfo)
 	}
 	box := ui.LegendBox(content, "Confirm", m.ui.width/2, 0, ui.ColBlue, true, -1)
-	return m.overlayHelp(lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box))
+	return lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 // viewTopics displays the topic manager list.


### PR DESCRIPTION
## Summary
- disable help on confirm dialogs
- keep selection index after toggling topics

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a7efed3e48324a32f5aae2cd5f3c3