### PR TITLE
Split topics manager into enabled/disabled panes

### DIFF
--- a/model.go
+++ b/model.go
@@ -160,12 +160,14 @@ type historyState struct {
 }
 
 type topicsState struct {
-	input      textinput.Model
-	items      []topicItem
-	list       list.Model
-	selected   int
-	chipBounds []chipBound
-	vp         viewport.Model
+	input        textinput.Model
+	items        []topicItem
+	enabled      list.Model
+	disabled     list.Model
+	focusEnabled bool
+	selected     int
+	chipBounds   []chipBound
+	vp           viewport.Model
 }
 
 type messageState struct {

--- a/model_init.go
+++ b/model_init.go
@@ -79,9 +79,12 @@ func initialModel(conns *Connections) *model {
 	hist.DisableQuitKeybindings()
 	statusChan := make(chan string, 10)
 
-	topicsList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
-	topicsList.DisableQuitKeybindings()
-	topicsList.SetShowTitle(false)
+	enabledList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
+	enabledList.DisableQuitKeybindings()
+	enabledList.SetShowTitle(false)
+	disabledList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
+	disabledList.DisableQuitKeybindings()
+	disabledList.SetShowTitle(false)
 	payloadList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
 	payloadList.DisableQuitKeybindings()
 	payloadList.SetShowTitle(false)
@@ -129,12 +132,14 @@ func initialModel(conns *Connections) *model {
 			selectionAnchor: -1,
 		},
 		topics: topicsState{
-			input:      ti,
-			items:      []topicItem{},
-			list:       topicsList,
-			selected:   -1,
-			chipBounds: []chipBound{},
-			vp:         viewport.New(0, 0),
+			input:        ti,
+			items:        []topicItem{},
+			enabled:      enabledList,
+			disabled:     disabledList,
+			focusEnabled: true,
+			selected:     -1,
+			chipBounds:   []chipBound{},
+			vp:           viewport.New(0, 0),
 		},
 		message: messageState{
 			input:    ta,

--- a/update_client.go
+++ b/update_client.go
@@ -282,13 +282,25 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			m.savePlannedTraces()
 			cmds = append(cmds, m.setMode(modeConnections))
 		case "ctrl+t":
-			items := []list.Item{}
+			m.sortTopics()
+			var enItems []list.Item
+			var disItems []list.Item
 			for _, tpc := range m.topics.items {
-				items = append(items, topicItem{title: tpc.title, active: tpc.active})
+				if tpc.active {
+					enItems = append(enItems, topicItem{title: tpc.title, active: tpc.active})
+				} else {
+					disItems = append(disItems, topicItem{title: tpc.title, active: tpc.active})
+				}
 			}
-			m.topics.list = list.New(items, list.NewDefaultDelegate(), m.ui.width-4, m.ui.height-4)
-			m.topics.list.DisableQuitKeybindings()
-			m.topics.list.SetShowTitle(false)
+			w := (m.ui.width - 4) / 2
+			h := m.ui.height - 4
+			m.topics.enabled = list.New(enItems, list.NewDefaultDelegate(), w, h)
+			m.topics.enabled.DisableQuitKeybindings()
+			m.topics.enabled.SetShowTitle(false)
+			m.topics.disabled = list.New(disItems, list.NewDefaultDelegate(), w, h)
+			m.topics.disabled.DisableQuitKeybindings()
+			m.topics.disabled.SetShowTitle(false)
+			m.topics.focusEnabled = true
 			cmds = append(cmds, m.setMode(modeTopics))
 		case "ctrl+p":
 			items := []list.Item{}

--- a/views.go
+++ b/views.go
@@ -233,12 +233,42 @@ func (m model) viewConfirmDelete() string {
 func (m model) viewTopics() string {
 	m.ui.elemPos = map[string]int{}
 	m.ui.elemPos[idTopicList] = 1
-	listView := m.topics.list.View()
 	help := ui.InfoStyle.Render("[space] toggle  [d]elete  [esc] back")
-	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
+
+	enPer := m.topics.enabled.Paginator.PerPage
+	enTotal := len(m.topics.enabled.Items())
+	enSP := -1.0
+	if enTotal > enPer {
+		start := m.topics.enabled.Paginator.Page * enPer
+		denom := enTotal - enPer
+		if denom > 0 {
+			enSP = float64(start) / float64(denom)
+		}
+	}
+	disPer := m.topics.disabled.Paginator.PerPage
+	disTotal := len(m.topics.disabled.Items())
+	disSP := -1.0
+	if disTotal > disPer {
+		start := m.topics.disabled.Paginator.Page * disPer
+		denom := disTotal - disPer
+		if denom > 0 {
+			disSP = float64(start) / float64(denom)
+		}
+	}
+
+	paneWidth := (m.ui.width - 4) / 2
+	m.topics.enabled.SetSize(paneWidth-2, m.ui.height-4)
+	m.topics.disabled.SetSize(paneWidth-2, m.ui.height-4)
+
 	focused := m.ui.focusOrder[m.ui.focusIndex] == idTopicList
-	view := ui.LegendBox(content, "Topics", m.ui.width-2, 0, ui.ColBlue, focused, -1)
-	return m.overlayHelp(view)
+	enFocused := focused && m.topics.focusEnabled
+	disFocused := focused && !m.topics.focusEnabled
+
+	enBox := ui.LegendBox(m.topics.enabled.View(), "Enabled", paneWidth, 0, ui.ColBlue, enFocused, enSP)
+	disBox := ui.LegendBox(m.topics.disabled.View(), "Disabled", paneWidth, 0, ui.ColBlue, disFocused, disSP)
+	lists := lipgloss.JoinHorizontal(lipgloss.Top, enBox, disBox)
+	content := lipgloss.JoinVertical(lipgloss.Left, lists, help)
+	return m.overlayHelp(content)
 }
 
 // viewPayloads shows stored payloads for reuse.


### PR DESCRIPTION
## Summary
- Track enabled and disabled topic lists separately
- Render Topics view with side-by-side Enabled and Disabled panes
- Simplify sorting and selection without duplicate slices

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a9685dbf08324b4303cd2c2362bba