### PR TITLE
Improve history item selection

### DIFF
--- a/history_delegate.go
+++ b/history_delegate.go
@@ -79,7 +79,7 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 			lines = append(lines, rendered)
 		}
 	}
-	if _, ok := d.m.history.selected[index]; ok {
+	if hi.isSelected != nil && *hi.isSelected {
 		for i, l := range lines {
 			lines[i] = lipgloss.NewStyle().Background(ui.ColDarkGray).Render(l)
 		}
@@ -88,7 +88,7 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	if hi.kind == "log" {
 		barColor = ui.ColDarkGray
 	}
-	if _, ok := d.m.history.selected[index]; ok {
+	if hi.isSelected != nil && *hi.isSelected {
 		barColor = ui.ColBlue
 	}
 	if index == d.m.history.list.Index() {

--- a/model.go
+++ b/model.go
@@ -85,10 +85,12 @@ type chipBound struct {
 }
 
 type historyItem struct {
-	timestamp time.Time
-	topic     string
-	payload   string
-	kind      string // pub, sub, log
+	timestamp           time.Time
+	topic               string
+	payload             string
+	kind                string // pub, sub, log
+	isSelected          *bool
+	isMarkedForDeletion *bool
 }
 
 func (h historyItem) FilterValue() string { return h.payload }
@@ -156,7 +158,6 @@ type historyState struct {
 	list            list.Model
 	items           []historyItem
 	store           *HistoryStore
-	selected        map[int]struct{}
 	selectionAnchor int
 }
 
@@ -308,6 +309,7 @@ type model struct {
 	confirmPrompt string
 	confirmInfo   string
 	confirmAction func()
+	confirmCancel func()
 
 	layout layoutConfig
 

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -38,6 +38,7 @@ func (m *model) startConfirm(prompt, info string, action func()) {
 	m.confirmPrompt = prompt
 	m.confirmInfo = info
 	m.confirmAction = action
+	m.confirmCancel = nil
 	_ = m.setMode(modeConfirmDelete)
 }
 

--- a/model_init.go
+++ b/model_init.go
@@ -125,7 +125,6 @@ func initialModel(conns *Connections) *model {
 			list:            hist,
 			items:           []historyItem{},
 			store:           nil,
-			selected:        make(map[int]struct{}),
 			selectionAnchor: -1,
 		},
 		topics: topicsState{

--- a/update.go
+++ b/update.go
@@ -361,10 +361,17 @@ func (m *model) updateConfirmDelete(msg tea.Msg) (model, tea.Cmd) {
 				m.confirmAction()
 				m.confirmAction = nil
 			}
+			if m.confirmCancel != nil {
+				m.confirmCancel = nil
+			}
 			cmd := m.setMode(m.previousMode())
 			m.scrollToFocused()
 			return *m, tea.Batch(cmd, listenStatus(m.connections.statusChan))
 		case "n", "esc":
+			if m.confirmCancel != nil {
+				m.confirmCancel()
+				m.confirmCancel = nil
+			}
 			cmd := m.setMode(m.previousMode())
 			m.scrollToFocused()
 			return *m, tea.Batch(cmd, listenStatus(m.connections.statusChan))
@@ -467,9 +474,12 @@ func (m *model) updateSelectionRange(idx int) {
 	if start > end {
 		start, end = end, start
 	}
-	m.history.selected = map[int]struct{}{}
-	for i := start; i <= end; i++ {
-		m.history.selected[i] = struct{}{}
+	for i := range m.history.items {
+		m.history.items[i].isSelected = nil
+	}
+	for i := start; i <= end && i < len(m.history.items); i++ {
+		v := true
+		m.history.items[i].isSelected = &v
 	}
 }
 


### PR DESCRIPTION
## Summary
- add per-message selection fields in `historyItem`
- track deletion directly from selected items and add `ctrl+a` to select all
- update `historyDelegate` rendering for per-item selection
- refine selection handling
- confirm before removing selected history messages
- simplify history delete marker handling
- drop temporary index slice when deleting history messages
- streamline deletion confirmation by removing a redundant flag

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688bc7e7b9448324a600aef25bd53e8f