### PR TITLE
Add archived message support with search and UI toggle

### DIFF
--- a/historystore_archive_test.go
+++ b/historystore_archive_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestArchiveAndSearchArchived(t *testing.T) {
+	hs := &HistoryStore{}
+	ts := time.Now()
+	msg := Message{Timestamp: ts, Topic: "t1", Payload: "p1", Kind: "pub"}
+	hs.Add(msg)
+	key := fmt.Sprintf("%s/%020d", msg.Topic, msg.Timestamp.UnixNano())
+	if err := hs.Archive(key); err != nil {
+		t.Fatalf("Archive failed: %v", err)
+	}
+	if res := hs.Search([]string{"t1"}, time.Time{}, time.Time{}, ""); len(res) != 0 {
+		t.Fatalf("expected no active messages, got %d", len(res))
+	}
+	res := hs.SearchArchived([]string{"t1"}, time.Time{}, time.Time{}, "")
+	if len(res) != 1 {
+		t.Fatalf("expected 1 archived message, got %d", len(res))
+	}
+	if !res[0].Archived {
+		t.Fatalf("archived flag not set")
+	}
+}

--- a/model.go
+++ b/model.go
@@ -89,6 +89,7 @@ type historyItem struct {
 	topic               string
 	payload             string
 	kind                string // pub, sub, log
+	archived            bool
 	isSelected          *bool
 	isMarkedForDeletion *bool
 }
@@ -159,6 +160,7 @@ type historyState struct {
 	items           []historyItem
 	store           *HistoryStore
 	selectionAnchor int
+	showArchived    bool
 }
 
 type paneState struct {

--- a/model_init.go
+++ b/model_init.go
@@ -198,8 +198,9 @@ func initialModel(conns *Connections) *model {
 		msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
 		items := make([]list.Item, len(msgs))
 		for i, mmsg := range msgs {
-			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind}
-			m.history.items = append(m.history.items, items[i].(historyItem))
+			hi := historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+			items[i] = hi
+			m.history.items = append(m.history.items, hi)
 		}
 		m.history.list.SetItems(items)
 	}

--- a/update.go
+++ b/update.go
@@ -101,16 +101,18 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 	if kind == "log" {
 		text = logText
 	}
-	hi := historyItem{timestamp: time.Now(), topic: topic, payload: text, kind: kind}
-	m.history.items = append(m.history.items, hi)
-	items := make([]list.Item, len(m.history.items))
-	for i, it := range m.history.items {
-		items[i] = it
+	hi := historyItem{timestamp: time.Now(), topic: topic, payload: text, kind: kind, archived: false}
+	if !m.history.showArchived {
+		m.history.items = append(m.history.items, hi)
+		items := make([]list.Item, len(m.history.items))
+		for i, it := range m.history.items {
+			items[i] = it
+		}
+		m.history.list.SetItems(items)
+		m.history.list.Select(len(items) - 1)
 	}
-	m.history.list.SetItems(items)
-	m.history.list.Select(len(items) - 1)
 	if m.history.store != nil {
-		m.history.store.Add(Message{Timestamp: time.Now(), Topic: topic, Payload: payload, Kind: kind})
+		m.history.store.Add(Message{Timestamp: time.Now(), Topic: topic, Payload: payload, Kind: kind, Archived: false})
 	}
 }
 

--- a/update_client.go
+++ b/update_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/list"
@@ -123,7 +124,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			m.mqttClient = nil
 		}
 	case "space":
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			idx := m.history.list.Index()
 			if idx >= 0 && idx < len(m.history.items) {
 				if m.history.items[idx].isSelected != nil && *m.history.items[idx].isSelected {
@@ -136,7 +137,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		}
 	case "shift+up":
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			if m.history.selectionAnchor == -1 {
 				m.history.selectionAnchor = m.history.list.Index()
 				if m.history.selectionAnchor >= 0 && m.history.selectionAnchor < len(m.history.items) {
@@ -151,7 +152,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		}
 	case "shift+down":
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			if m.history.selectionAnchor == -1 {
 				m.history.selectionAnchor = m.history.list.Index()
 				if m.history.selectionAnchor >= 0 && m.history.selectionAnchor < len(m.history.items) {
@@ -234,13 +235,36 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			m.layout.topics.height++
 		}
 	case "ctrl+a":
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			for i := range m.history.items {
 				v := true
 				m.history.items[i].isSelected = &v
 			}
 			if len(m.history.items) > 0 {
 				m.history.selectionAnchor = 0
+			}
+		}
+	case "ctrl+l":
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && m.history.store != nil {
+			m.history.showArchived = !m.history.showArchived
+			var msgs []Message
+			if m.history.showArchived {
+				msgs = m.history.store.SearchArchived(nil, time.Time{}, time.Time{}, "")
+			} else {
+				msgs = m.history.store.Search(nil, time.Time{}, time.Time{}, "")
+			}
+			m.history.items = make([]historyItem, len(msgs))
+			items := make([]list.Item, len(msgs))
+			for i, mm := range msgs {
+				hi := historyItem{timestamp: mm.Timestamp, topic: mm.Topic, payload: mm.Payload, kind: mm.Kind, archived: mm.Archived}
+				m.history.items[i] = hi
+				items[i] = hi
+			}
+			m.history.list.SetItems(items)
+			if len(items) > 0 {
+				m.history.list.Select(len(items) - 1)
+			} else {
+				m.history.list.Select(-1)
 			}
 		}
 	case "up", "down":
@@ -288,8 +312,50 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 				m.rebuildActiveTopicList()
 			}
 		}
+	case "a":
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
+			if len(m.history.items) == 0 {
+				break
+			}
+			archived := false
+			for i := len(m.history.items) - 1; i >= 0; i-- {
+				it := m.history.items[i]
+				if it.isSelected != nil && *it.isSelected {
+					key := fmt.Sprintf("%s/%020d", it.topic, it.timestamp.UnixNano())
+					if m.history.store != nil {
+						_ = m.history.store.Archive(key)
+					}
+					m.history.items = append(m.history.items[:i], m.history.items[i+1:]...)
+					archived = true
+				}
+			}
+			if !archived {
+				idx := m.history.list.Index()
+				if idx >= 0 && idx < len(m.history.items) {
+					it := m.history.items[idx]
+					key := fmt.Sprintf("%s/%020d", it.topic, it.timestamp.UnixNano())
+					if m.history.store != nil {
+						_ = m.history.store.Archive(key)
+					}
+					m.history.items = append(m.history.items[:idx], m.history.items[idx+1:]...)
+				}
+			}
+			items := make([]list.Item, len(m.history.items))
+			for i, it := range m.history.items {
+				it.isSelected = nil
+				m.history.items[i] = it
+				items[i] = it
+			}
+			m.history.list.SetItems(items)
+			if len(m.history.items) == 0 {
+				m.history.list.Select(-1)
+			} else if m.history.list.Index() >= len(m.history.items) {
+				m.history.list.Select(len(m.history.items) - 1)
+			}
+			m.history.selectionAnchor = -1
+		}
 	case "d":
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			if len(m.history.items) == 0 {
 				break
 			}
@@ -390,7 +456,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 func (m *model) handleClientMouse(msg tea.MouseMsg) tea.Cmd {
 	var cmds []tea.Cmd
 	if msg.Action == tea.MouseActionPress && (msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown) {
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			var hCmd tea.Cmd
 			m.history.list, hCmd = m.history.list.Update(msg)
 			cmds = append(cmds, hCmd)
@@ -405,7 +471,7 @@ func (m *model) handleClientMouse(msg tea.MouseMsg) tea.Cmd {
 	}
 	if msg.Type == tea.MouseLeft {
 		cmds = append(cmds, m.focusFromMouse(msg.Y))
-		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			idx := m.historyIndexAt(msg.Y)
 			if idx >= 0 {
 				m.history.list.Select(idx)
@@ -517,10 +583,15 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 	if m.history.list.FilterState() == list.Filtering {
 		q := m.history.list.FilterInput.Value()
 		topics, start, end, text := parseHistoryQuery(q)
-		msgs := m.history.store.Search(topics, start, end, text)
+		var msgs []Message
+		if m.history.showArchived {
+			msgs = m.history.store.SearchArchived(topics, start, end, text)
+		} else {
+			msgs = m.history.store.Search(topics, start, end, text)
+		}
 		items := make([]list.Item, len(msgs))
 		for i, mmsg := range msgs {
-			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind}
+			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
 		}
 		m.history.list.SetItems(items)
 	} else {


### PR DESCRIPTION
## Summary
- allow messages to be archived and searched separately from active history
- add UI actions to archive entries and toggle an archived view

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c94ea3b788324b7d568a9959c160c