### PR TITLE
fix history filtering and default time range

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view to filter messages. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view to filter messages. Filters accept tokens like `topic=`, `start=` and `end=` and default to showing the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -21,4 +21,5 @@
 - Esc navigates back
 - Use arrows or j/k to move through lists
 - Ctrl+Up/Down scrolls the view
-- Press '/' in history to filter
+- Press '/' in history to filter; use `topic=`, `start=` and `end=` to limit
+  results. Filters default to the last hour.

--- a/update_client.go
+++ b/update_client.go
@@ -588,9 +588,13 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, histCmd)
 	}
 
-	if m.history.list.FilterState() == list.Filtering {
+	if st := m.history.list.FilterState(); st == list.Filtering || st == list.FilterApplied {
 		q := m.history.list.FilterInput.Value()
 		topics, start, end, text := parseHistoryQuery(q)
+		if start.IsZero() && end.IsZero() {
+			end = time.Now()
+			start = end.Add(-time.Hour)
+		}
 		var msgs []Message
 		if m.history.showArchived {
 			msgs = m.history.store.SearchArchived(topics, start, end, text)


### PR DESCRIPTION
## Summary
- keep history list filtered after applying search
- default history results to last hour unless start/end specified
- document history filter tokens and default time window

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ca34e30408324bf03818834aeae3d