### PR TITLE
docs: document archive, delete and scroll shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
 ## Agent Notes
 The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name. The importer code lives in the main package and runs via these flags.
 Press `Ctrl+D` from any screen to exit the program.
+Scroll with `Ctrl+Up`/`Ctrl+Down` or `Ctrl+K`/`Ctrl+J`. In history,
+`a` archives messages and `Delete` removes them.
 
 ### Recent Experience
 - Keyboard shortcuts bound to plain letters can interfere with text entry. Use `Ctrl` combinations for global actions.

--- a/README.md
+++ b/README.md
@@ -64,19 +64,39 @@ Tips:
 
 ### Shortcuts
 
+#### Global
+
 | Action | Key |
 | --- | --- |
+| Copy selected entry | `Ctrl+C` |
+| Exit the program | `Ctrl+D` |
+| Manage payloads | `Ctrl+P` |
+| Manage topics | `Ctrl+T` |
+| Manage traces | `Ctrl+R` |
 | Open broker manager | `Ctrl+B` |
 | Publish message | `Ctrl+S` or `Ctrl+Enter` |
-| Manage topics | `Ctrl+T` |
-| Manage payloads | `Ctrl+P` |
-| Manage traces | `Ctrl+R` |
-| Copy selected entry | `Ctrl+C` |
-| Scroll view | `Ctrl+Up` / `Ctrl+Down` |
-| Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
+| Scroll view | `Ctrl+Up`/`Ctrl+Down` or `Ctrl+K`/`Ctrl+J` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view to filter messages. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+#### Navigation
+
+- `Esc` navigates back
+- Enter subscribes to the typed topic
+- Tab/Shift+Tab cycle focus
+- Use ↑/↓ or `j`/`k` to move through lists
+- All `Ctrl` shortcuts work even when an input is active
+
+#### Broker Manager
+
+- `x` disconnects the selected profile
+
+#### History View
+
+- Shift selects ranges; `Ctrl+A` selects all
+- `a` archives selected messages
+- `Delete` removes selected messages
+- `Ctrl+L` toggles archived view
+- Press `/` to filter messages
 
 ## License
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,24 +1,35 @@
 # Shortcuts
 
+## Global
+
 | Key | Action |
 | --- | ------ |
+| Ctrl+C | Copy selected entry |
+| Ctrl+D | Exit the program |
+| Ctrl+P | Manage payloads |
+| Ctrl+T | Manage topics |
+| Ctrl+R | Manage traces |
 | Ctrl+B | Open broker manager |
 | Ctrl+S / Ctrl+Enter | Publish message |
-| Ctrl+T | Manage topics |
-| Ctrl+P | Manage payloads |
-| Ctrl+R | Manage traces |
-| Ctrl+C | Copy selected entry |
-| Ctrl+Up/Down | Scroll view |
-| Ctrl+D | Exit the program |
-| Ctrl+Shift+Up | Resize panels (up) |
-| Ctrl+Shift+Down | Resize panels (down) |
+| Ctrl+Shift+Up / Ctrl+Shift+Down | Resize panels |
+| Ctrl+Up/Down or Ctrl+K/J | Scroll view |
 
-## Other Keys
+## Navigation
 
-- Tab/Shift+Tab cycle focus
-- Enter subscribes to the typed topic
-- 'x' disconnects in the broker manager
 - Esc navigates back
+- Enter subscribes to the typed topic
+- Tab/Shift+Tab cycle focus
 - Use arrows or j/k to move through lists
-- Ctrl+Up/Down scrolls the view
-- Press '/' in history to filter
+- All Ctrl shortcuts work even when an input is active
+
+## Broker Manager
+
+- 'x' disconnects the selected profile
+
+## History View
+
+- Shift selects ranges; Ctrl+A selects all
+- 'a' archives selected messages
+- Delete removes selected messages
+- Ctrl+L toggles archived view
+- Press '/' to filter messages


### PR DESCRIPTION
## Summary
- mention new scrolling shortcuts
- note archive and delete keys in help docs
- add same shortcuts to contributor notes
- group shortcuts by view for readability

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ca1f1e58483249e906edc80e115f1