### PR TITLE
Toggle history selection with Ctrl+A

### DIFF
--- a/history_select_test.go
+++ b/history_select_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that ctrl+a toggles history selection
+func TestCtrlATogglesHistorySelection(t *testing.T) {
+	m := initialModel(nil)
+	m.history.items = []historyItem{
+		{timestamp: time.Now(), topic: "t1", payload: "p1", kind: "pub"},
+		{timestamp: time.Now(), topic: "t2", payload: "p2", kind: "pub"},
+	}
+	items := make([]list.Item, len(m.history.items))
+	for i, it := range m.history.items {
+		items[i] = it
+	}
+	m.history.list.SetItems(items)
+	m.setFocus(idHistory)
+
+	// First ctrl+a selects all
+	m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	for i, it := range m.history.items {
+		if it.isSelected == nil || !*it.isSelected {
+			t.Fatalf("item %d not selected", i)
+		}
+	}
+	if m.history.selectionAnchor != 0 {
+		t.Fatalf("selectionAnchor = %d, want 0", m.history.selectionAnchor)
+	}
+
+	// Second ctrl+a deselects all
+	m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	for i, it := range m.history.items {
+		if it.isSelected != nil {
+			t.Fatalf("item %d still selected", i)
+		}
+	}
+	if m.history.selectionAnchor != -1 {
+		t.Fatalf("selectionAnchor = %d, want -1", m.history.selectionAnchor)
+	}
+}

--- a/update_client.go
+++ b/update_client.go
@@ -236,12 +236,26 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 		}
 	case "ctrl+a":
 		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
+			allSelected := true
 			for i := range m.history.items {
-				v := true
-				m.history.items[i].isSelected = &v
+				if m.history.items[i].isSelected == nil || !*m.history.items[i].isSelected {
+					allSelected = false
+					break
+				}
 			}
-			if len(m.history.items) > 0 {
-				m.history.selectionAnchor = 0
+			if allSelected {
+				for i := range m.history.items {
+					m.history.items[i].isSelected = nil
+				}
+				m.history.selectionAnchor = -1
+			} else {
+				for i := range m.history.items {
+					v := true
+					m.history.items[i].isSelected = &v
+				}
+				if len(m.history.items) > 0 {
+					m.history.selectionAnchor = 0
+				}
 			}
 		}
 	case "ctrl+l":


### PR DESCRIPTION
## Summary
- allow pressing Ctrl+A again in history view to deselect all
- add regression test for Ctrl+A toggle behavior
- simplify selection toggle logic to avoid unnecessary checks

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ca2546e388324a4fc3df49a371d1f