### PR TITLE
fix history filtering and default time range

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view to filter messages. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic auto-completion (Tab) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight). Start and end default to the last hour and can be cleared to search all time. Active filters show above the history list and `Ctrl+F` clears them. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight). Start and end default to the last hour on first open and stay blank once removed, letting you search all time. Active filters show above the history list and `Ctrl+F` clears them. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic auto-completion (Tab) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab cycles matches) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab cycles matches) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ Tips:
 | Manage topics | `Ctrl+T` |
 | Manage payloads | `Ctrl+P` |
 | Manage traces | `Ctrl+R` |
+| Clear history filters | `Ctrl+F` |
 | Copy selected entry | `Ctrl+C` |
 | Scroll view | `Ctrl+Up` / `Ctrl+Down` |
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight) and start/end inputs prefilled to the last hour. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight). Start and end default to the last hour and can be cleared to search all time. Active filters show above the history list and `Ctrl+F` clears them. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Tips:
 | Exit the program | `Ctrl+D` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
 
-Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight). Start and end default to the last hour on first open and stay blank once removed, letting you search all time. Active filters show above the history list and `Ctrl+F` clears them. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
+Other keys: `Tab` and `Shift+Tab` cycle focus, `Enter` subscribes to the typed topic, `x` disconnects in the broker manager and `Esc` navigates back. Use ↑/↓ or `j`/`k` to move through lists, hold `Shift` for range selection in history. Press `/` in the history view for a filter dialog with topic suggestions (Tab or arrows cycle matches; `Enter` or space accepts the highlight). A text field matches message contents, and start and end default to the last hour on first open and stay blank once removed, letting you search all time. Active filters show above the history list and `Ctrl+F` clears them. `Ctrl+Up`/`Ctrl+Down` scrolls the view. All `Ctrl` shortcuts work even when an input is active.
 
 ## License
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -7,6 +7,7 @@
 | Ctrl+T | Manage topics |
 | Ctrl+P | Manage payloads |
 | Ctrl+R | Manage traces |
+| Ctrl+F | Clear history filters |
 | Ctrl+C | Copy selected entry |
 | Ctrl+Up/Down | Scroll view |
 | Ctrl+D | Exit the program |
@@ -23,4 +24,6 @@
 - Ctrl+Up/Down scrolls the view
 - Press '/' in history for a filter dialog with topic suggestions shown
   under the field; Tab or arrows cycle matches and Enter or space accepts
-  the highlight. Start and end fields default to the last hour.
+  the highlight. Start and end fields default to the last hour and can be
+  cleared to search all time. Active filters appear above the history list
+  and `Ctrl+F` resets them.

--- a/docs/help.md
+++ b/docs/help.md
@@ -21,4 +21,5 @@
 - Esc navigates back
 - Use arrows or j/k to move through lists
 - Ctrl+Up/Down scrolls the view
-- Press '/' in history to filter
+- Press '/' in history for a filter dialog with topic suggestions (Tab to
+  complete) and start/end fields defaulting to the last hour.

--- a/docs/help.md
+++ b/docs/help.md
@@ -21,5 +21,6 @@
 - Esc navigates back
 - Use arrows or j/k to move through lists
 - Ctrl+Up/Down scrolls the view
-- Press '/' in history for a filter dialog with topic suggestions (Tab to
-  complete) and start/end fields defaulting to the last hour.
+- Press '/' in history for a filter dialog with topic suggestions shown
+  under the field; Tab cycles matches. Start and end fields default to the
+  last hour.

--- a/docs/help.md
+++ b/docs/help.md
@@ -22,5 +22,5 @@
 - Use arrows or j/k to move through lists
 - Ctrl+Up/Down scrolls the view
 - Press '/' in history for a filter dialog with topic suggestions shown
-  under the field; Tab or arrows cycle matches. Start and end fields
-  default to the last hour.
+  under the field; Tab or arrows cycle matches and Enter or space accepts
+  the highlight. Start and end fields default to the last hour.

--- a/docs/help.md
+++ b/docs/help.md
@@ -24,6 +24,6 @@
 - Ctrl+Up/Down scrolls the view
 - Press '/' in history for a filter dialog with topic suggestions shown
   under the field; Tab or arrows cycle matches and Enter or space accepts
-  the highlight. Start and end fields default to the last hour and can be
-  cleared to search all time. Active filters appear above the history list
-  and `Ctrl+F` resets them.
+  the highlight. Start and end fields default to the last hour on first
+  open and stay blank once removed so you can search all time. Active
+  filters appear above the history list and `Ctrl+F` resets them.

--- a/docs/help.md
+++ b/docs/help.md
@@ -22,5 +22,5 @@
 - Use arrows or j/k to move through lists
 - Ctrl+Up/Down scrolls the view
 - Press '/' in history for a filter dialog with topic suggestions shown
-  under the field; Tab cycles matches. Start and end fields default to the
-  last hour.
+  under the field; Tab or arrows cycle matches. Start and end fields
+  default to the last hour.

--- a/docs/help.md
+++ b/docs/help.md
@@ -24,6 +24,7 @@
 - Ctrl+Up/Down scrolls the view
 - Press '/' in history for a filter dialog with topic suggestions shown
   under the field; Tab or arrows cycle matches and Enter or space accepts
-  the highlight. Start and end fields default to the last hour on first
-  open and stay blank once removed so you can search all time. Active
-  filters appear above the history list and `Ctrl+F` resets them.
+  the highlight. A text box lets you match message contents, and start
+  and end fields default to the last hour on first open and stay blank
+  once removed so you can search all time. Active filters appear above the
+  history list and `Ctrl+F` resets them.

--- a/formutil.go
+++ b/formutil.go
@@ -194,14 +194,13 @@ func (s *suggestField) SuggestionsView() string {
 	}
 	items := make([]string, len(s.suggestions))
 	for i, sug := range s.suggestions {
-		st := ui.ChipInactive
+		st := lipgloss.NewStyle().Foreground(ui.ColBlue)
 		if i == s.sel {
-			st = ui.ChipStyle.Copy().BorderForeground(ui.ColPink).Foreground(ui.ColPink).Faint(false)
+			st = st.Foreground(ui.ColPink)
 		}
 		items[i] = st.Render(sug)
 	}
-	row := lipgloss.JoinHorizontal(lipgloss.Top, items...)
-	return ui.BorderStyle.Render(row)
+	return strings.Join(items, " ")
 }
 
 // WantsKey reports whether the field wants to handle the key itself to cycle

--- a/formutil.go
+++ b/formutil.go
@@ -208,7 +208,7 @@ func (s *suggestField) SuggestionsView() string {
 		}
 		items[i] = st.Render(sug)
 	}
-	return strings.Join(items, " ")
+	return strings.Join(items, "\n")
 }
 
 // WantsKey reports whether the field wants to handle the key itself to cycle

--- a/formutil.go
+++ b/formutil.go
@@ -168,6 +168,14 @@ func (s *suggestField) Update(msg tea.Msg) tea.Cmd {
 				s.CursorEnd()
 				return nil
 			}
+		case "enter", " ", "space":
+			if len(s.suggestions) > 0 && s.sel >= 0 {
+				s.SetValue(s.suggestions[s.sel])
+				s.suggestions = nil
+				s.sel = -1
+				s.CursorEnd()
+				return nil
+			}
 		}
 	}
 	cmd := s.textField.Update(msg)
@@ -207,7 +215,7 @@ func (s *suggestField) SuggestionsView() string {
 // suggestions instead of moving focus.
 func (s *suggestField) WantsKey(k tea.KeyMsg) bool {
 	switch k.String() {
-	case "tab", "shift+tab", "up", "down":
+	case "tab", "shift+tab", "up", "down", "enter", " ", "space":
 		return len(s.suggestions) > 0
 	default:
 		return false

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -56,3 +56,43 @@ func TestHistoryBoxLayout(t *testing.T) {
 		}
 	}
 }
+
+// Test that active filters are shown inside the history box rather than in the border.
+func TestHistoryFilterDisplayedInsideBox(t *testing.T) {
+	m := initialModel(nil)
+	m.history.filterQuery = "topic=foo"
+	m.history.store = &HistoryStore{}
+	m.appendHistory("foo", "bar", "pub", "")
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
+	view := m.viewClient()
+	lines := strings.Split(view, "\n")
+	var hist []string
+	collecting := false
+	for _, l := range lines {
+		if strings.Contains(l, "History") {
+			collecting = true
+		}
+		if collecting {
+			hist = append(hist, l)
+			if strings.Contains(l, "\u2518") {
+				break
+			}
+		}
+	}
+	if len(hist) < 2 {
+		t.Fatalf("history box not found in view")
+	}
+	if strings.Contains(hist[0], "topic=foo") {
+		t.Fatalf("filter query should not appear in border")
+	}
+	found := false
+	for _, l := range hist[1:] {
+		if strings.Contains(l, "topic=foo") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("filter query not found inside history box")
+	}
+}

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -160,3 +160,16 @@ func TestHistoryFilterLineWidth(t *testing.T) {
 		}
 	}
 }
+
+// Test that the history help legend remains visible after applying a filter.
+func TestHistoryHelpVisibleWithFilter(t *testing.T) {
+	m := initialModel(nil)
+	m.history.store = &HistoryStore{}
+	m.history.filterQuery = "topic=foo"
+	m.appendHistory("foo", "bar", "pub", "")
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
+	view := m.viewClient()
+	if !strings.Contains(view, "\u2191/k up") {
+		t.Fatalf("expected history shortcuts in view, got %q", view)
+	}
+}

--- a/historyfilter.go
+++ b/historyfilter.go
@@ -24,17 +24,22 @@ type historyFilterForm struct {
 }
 
 // newHistoryFilterForm builds a form with optional prefilled values.
-// If start and end are zero, it defaults to the last hour.
+// Start and end remain blank when zero, allowing searches across all time.
 func newHistoryFilterForm(topics []string, topic string, start, end time.Time) historyFilterForm {
-	if start.IsZero() && end.IsZero() {
-		end = time.Now()
-		start = end.Add(-time.Hour)
-	}
 	sort.Strings(topics)
 	tf := newSuggestField(topics, "topic")
 	tf.SetValue(topic)
-	sf := newTextField(start.Format(time.RFC3339), "start (RFC3339)")
-	ef := newTextField(end.Format(time.RFC3339), "end (RFC3339)")
+
+	sf := newTextField("", "start (RFC3339)")
+	if !start.IsZero() {
+		sf.SetValue(start.Format(time.RFC3339))
+	}
+
+	ef := newTextField("", "end (RFC3339)")
+	if !end.IsZero() {
+		ef.SetValue(end.Format(time.RFC3339))
+	}
+
 	f := historyFilterForm{
 		topic: tf,
 		start: sf,

--- a/historyfilter.go
+++ b/historyfilter.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/marang/goemqutiti/ui"
 )
 
 const (
@@ -19,30 +18,25 @@ const (
 // historyFilterForm captures filter inputs for history searches.
 type historyFilterForm struct {
 	Form
-	topic       *textField
-	start       *textField
-	end         *textField
-	topics      []string
-	suggestions []string
-	suggestIdx  int
+	topic *suggestField
+	start *textField
+	end   *textField
 }
 
 // newHistoryFilterForm builds a form prefilled with the last hour.
 func newHistoryFilterForm(topics []string) historyFilterForm {
 	end := time.Now()
 	start := end.Add(-time.Hour)
-	tf := newTextField("", "topic")
+	sort.Strings(topics)
+	tf := newSuggestField(topics, "topic")
 	sf := newTextField(start.Format(time.RFC3339), "start (RFC3339)")
 	ef := newTextField(end.Format(time.RFC3339), "end (RFC3339)")
 	f := historyFilterForm{
-		topic:      tf,
-		start:      sf,
-		end:        ef,
-		topics:     append([]string(nil), topics...),
-		suggestIdx: -1,
+		topic: tf,
+		start: sf,
+		end:   ef,
 	}
 	f.fields = []formField{tf, sf, ef}
-	sort.Strings(f.topics)
 	f.ApplyFocus()
 	return f
 }
@@ -52,43 +46,6 @@ func (f historyFilterForm) Update(msg tea.Msg) (historyFilterForm, tea.Cmd) {
 	var cmd tea.Cmd
 	switch m := msg.(type) {
 	case tea.KeyMsg:
-		if f.focus == idxFilterTopic {
-			switch m.String() {
-			case "tab", "down":
-				if len(f.suggestions) == 0 {
-					prefix := f.topic.Value()
-					for _, t := range f.topics {
-						if strings.HasPrefix(t, prefix) {
-							f.suggestions = append(f.suggestions, t)
-						}
-					}
-				}
-				if len(f.suggestions) > 0 {
-					f.suggestIdx = (f.suggestIdx + 1) % len(f.suggestions)
-					f.topic.SetValue(f.suggestions[f.suggestIdx])
-					f.topic.CursorEnd()
-				}
-				return f, nil
-			case "shift+tab", "up":
-				if len(f.suggestions) == 0 {
-					prefix := f.topic.Value()
-					for _, t := range f.topics {
-						if strings.HasPrefix(t, prefix) {
-							f.suggestions = append(f.suggestions, t)
-						}
-					}
-				}
-				if len(f.suggestions) > 0 {
-					f.suggestIdx--
-					if f.suggestIdx < 0 {
-						f.suggestIdx = len(f.suggestions) - 1
-					}
-					f.topic.SetValue(f.suggestions[f.suggestIdx])
-					f.topic.CursorEnd()
-				}
-				return f, nil
-			}
-		}
 		f.CycleFocus(m)
 	case tea.MouseMsg:
 		if m.Action == tea.MouseActionPress && m.Button == tea.MouseButtonLeft {
@@ -101,19 +58,6 @@ func (f historyFilterForm) Update(msg tea.Msg) (historyFilterForm, tea.Cmd) {
 	if len(f.fields) > 0 {
 		cmd = f.fields[f.focus].Update(msg)
 	}
-	if f.focus == idxFilterTopic {
-		prefix := f.topic.Value()
-		f.suggestions = f.suggestions[:0]
-		f.suggestIdx = -1
-		for _, t := range f.topics {
-			if prefix == "" || strings.HasPrefix(t, prefix) {
-				f.suggestions = append(f.suggestions, t)
-				if len(f.suggestions) == 5 {
-					break
-				}
-			}
-		}
-	}
 	return f, cmd
 }
 
@@ -122,16 +66,8 @@ func (f historyFilterForm) View() string {
 	lines := []string{
 		fmt.Sprintf("Topic: %s", f.topic.View()),
 	}
-	if f.focus == idxFilterTopic && len(f.suggestions) > 0 {
-		suggs := make([]string, len(f.suggestions))
-		for i, s := range f.suggestions {
-			if i == f.suggestIdx {
-				suggs[i] = ui.FocusedStyle.Render(s)
-			} else {
-				suggs[i] = s
-			}
-		}
-		lines = append(lines, "       "+strings.Join(suggs, " "))
+	if sugg := f.topic.SuggestionsView(); sugg != "" {
+		lines = append(lines, "       "+sugg)
 	}
 	lines = append(lines,
 		fmt.Sprintf("Start: %s", f.start.View()),

--- a/historyfilter.go
+++ b/historyfilter.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	idxFilterTopic = iota
+	idxFilterStart
+	idxFilterEnd
+)
+
+// historyFilterForm captures filter inputs for history searches.
+type historyFilterForm struct {
+	Form
+	topic  *textField
+	start  *textField
+	end    *textField
+	topics []string
+}
+
+// newHistoryFilterForm builds a form prefilled with the last hour.
+func newHistoryFilterForm(topics []string) historyFilterForm {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+	tf := newTextField("", "topic")
+	sf := newTextField(start.Format(time.RFC3339), "start (RFC3339)")
+	ef := newTextField(end.Format(time.RFC3339), "end (RFC3339)")
+	f := historyFilterForm{
+		topic:  tf,
+		start:  sf,
+		end:    ef,
+		topics: append([]string(nil), topics...),
+	}
+	f.fields = []formField{tf, sf, ef}
+	sort.Strings(f.topics)
+	f.ApplyFocus()
+	return f
+}
+
+// Update handles focus cycling and topic completion.
+func (f historyFilterForm) Update(msg tea.Msg) (historyFilterForm, tea.Cmd) {
+	var cmd tea.Cmd
+	switch m := msg.(type) {
+	case tea.KeyMsg:
+		if f.focus == idxFilterTopic && m.String() == "tab" {
+			prefix := f.topic.Value()
+			for _, t := range f.topics {
+				if strings.HasPrefix(t, prefix) {
+					f.topic.SetValue(t)
+					f.topic.CursorEnd()
+					break
+				}
+			}
+			return f, nil
+		}
+		f.CycleFocus(m)
+	case tea.MouseMsg:
+		if m.Action == tea.MouseActionPress && m.Button == tea.MouseButtonLeft {
+			if m.Y >= 1 && m.Y-1 < len(f.fields) {
+				f.focus = m.Y - 1
+			}
+		}
+	}
+	f.ApplyFocus()
+	if len(f.fields) > 0 {
+		cmd = f.fields[f.focus].Update(msg)
+	}
+	return f, cmd
+}
+
+// View renders the filter fields with labels.
+func (f historyFilterForm) View() string {
+	lines := []string{
+		fmt.Sprintf("Topic: %s", f.topic.View()),
+		fmt.Sprintf("Start: %s", f.start.View()),
+		fmt.Sprintf("End:   %s", f.end.View()),
+	}
+	return strings.Join(lines, "\n")
+}
+
+// query builds a history search string.
+func (f historyFilterForm) query() string {
+	var parts []string
+	if v := f.topic.Value(); v != "" {
+		parts = append(parts, "topic="+v)
+	}
+	if v := f.start.Value(); v != "" {
+		parts = append(parts, "start="+v)
+	}
+	if v := f.end.Value(); v != "" {
+		parts = append(parts, "end="+v)
+	}
+	return strings.Join(parts, " ")
+}

--- a/historyfilter.go
+++ b/historyfilter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 const (
@@ -63,11 +64,11 @@ func (f historyFilterForm) Update(msg tea.Msg) (historyFilterForm, tea.Cmd) {
 
 // View renders the filter fields with labels.
 func (f historyFilterForm) View() string {
-	lines := []string{
-		fmt.Sprintf("Topic: %s", f.topic.View()),
-	}
+	line := fmt.Sprintf("Topic: %s", f.topic.View())
+	lines := []string{line}
 	if sugg := f.topic.SuggestionsView(); sugg != "" {
-		lines = append(lines, "       "+sugg)
+		sep := strings.Repeat("─", lipgloss.Width(line))
+		lines = append(lines, sep, sugg)
 	}
 	lines = append(lines,
 		fmt.Sprintf("Start: %s", f.start.View()),

--- a/historyfilter.go
+++ b/historyfilter.go
@@ -23,12 +23,16 @@ type historyFilterForm struct {
 	end   *textField
 }
 
-// newHistoryFilterForm builds a form prefilled with the last hour.
-func newHistoryFilterForm(topics []string) historyFilterForm {
-	end := time.Now()
-	start := end.Add(-time.Hour)
+// newHistoryFilterForm builds a form with optional prefilled values.
+// If start and end are zero, it defaults to the last hour.
+func newHistoryFilterForm(topics []string, topic string, start, end time.Time) historyFilterForm {
+	if start.IsZero() && end.IsZero() {
+		end = time.Now()
+		start = end.Add(-time.Hour)
+	}
 	sort.Strings(topics)
 	tf := newSuggestField(topics, "topic")
+	tf.SetValue(topic)
 	sf := newTextField(start.Format(time.RFC3339), "start (RFC3339)")
 	ef := newTextField(end.Format(time.RFC3339), "end (RFC3339)")
 	f := historyFilterForm{

--- a/historystore.go
+++ b/historystore.go
@@ -217,6 +217,21 @@ func (i *HistoryStore) SearchArchived(topics []string, start, end time.Time, pay
 	return out
 }
 
+// Count reports the number of stored messages. When archived is true,
+// only archived messages are counted; otherwise only unarchived messages
+// are included.
+func (i *HistoryStore) Count(archived bool) int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	c := 0
+	for _, m := range i.msgs {
+		if m.Archived == archived {
+			c++
+		}
+	}
+	return c
+}
+
 // parseHistoryQuery interprets a filter string in the form:
 //
 //	"topic=a,b start=2023-01-02T15:04:05Z end=2023-01-02T16:00 payload=foo".

--- a/historystore_search_test.go
+++ b/historystore_search_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Test that HistoryStore.Search respects topic, time, and payload filters.
+func TestHistoryStoreSearch(t *testing.T) {
+	hs := &HistoryStore{}
+	now := time.Now()
+	hs.Add(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub"})
+	hs.Add(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub"})
+
+	res := hs.Search([]string{"a"}, now.Add(-1*time.Hour), now, "")
+	if len(res) != 1 || res[0].Topic != "a" {
+		t.Fatalf("topic filter failed: %#v", res)
+	}
+
+	res = hs.Search(nil, now.Add(-1*time.Hour), now, "foo")
+	if len(res) != 1 || res[0].Payload != "foo" {
+		t.Fatalf("payload filter failed: %#v", res)
+	}
+
+	res = hs.Search([]string{"b"}, now.Add(-1*time.Hour), now, "")
+	if len(res) != 0 {
+		t.Fatalf("time filter failed: %#v", res)
+	}
+}

--- a/model.go
+++ b/model.go
@@ -41,6 +41,7 @@ var focusByMode = map[appMode][]string{
 	modeEditTrace:      {idHelp},
 	modeViewTrace:      {idHelp},
 	modeImporter:       {idHelp},
+	modeHistoryFilter:  {idHelp},
 	modeHelp:           {idHelp},
 }
 
@@ -126,6 +127,7 @@ const (
 	modeEditTrace
 	modeViewTrace
 	modeImporter
+	modeHistoryFilter
 	modeHelp
 )
 
@@ -161,6 +163,7 @@ type historyState struct {
 	store           *HistoryStore
 	selectionAnchor int
 	showArchived    bool
+	filterForm      *historyFilterForm
 }
 
 type paneState struct {

--- a/model.go
+++ b/model.go
@@ -164,6 +164,7 @@ type historyState struct {
 	selectionAnchor int
 	showArchived    bool
 	filterForm      *historyFilterForm
+	filterQuery     string
 }
 
 type paneState struct {

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -42,6 +42,17 @@ func (m *model) startConfirm(prompt, info string, action func()) {
 	_ = m.setMode(modeConfirmDelete)
 }
 
+// startHistoryFilter opens the history filter form.
+func (m *model) startHistoryFilter() tea.Cmd {
+	var topics []string
+	for _, t := range m.topics.items {
+		topics = append(topics, t.title)
+	}
+	hf := newHistoryFilterForm(topics)
+	m.history.filterForm = &hf
+	return m.setMode(modeHistoryFilter)
+}
+
 // subscribeActiveTopics subscribes the MQTT client to all currently active topics.
 func (m *model) subscribeActiveTopics() {
 	if m.mqttClient == nil {

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -49,19 +49,19 @@ func (m *model) startHistoryFilter() tea.Cmd {
 	for _, t := range m.topics.items {
 		topics = append(topics, t.title)
 	}
-	var topic string
+	var topic, payload string
 	var start, end time.Time
 	if m.history.filterQuery != "" {
-		ts, s, e, _ := parseHistoryQuery(m.history.filterQuery)
+		ts, s, e, p := parseHistoryQuery(m.history.filterQuery)
 		if len(ts) > 0 {
 			topic = ts[0]
 		}
-		start, end = s, e
+		start, end, payload = s, e, p
 	} else {
 		end = time.Now()
 		start = end.Add(-time.Hour)
 	}
-	hf := newHistoryFilterForm(topics, topic, start, end)
+	hf := newHistoryFilterForm(topics, topic, payload, start, end)
 	m.history.filterForm = &hf
 	return m.setMode(modeHistoryFilter)
 }

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -109,6 +109,7 @@ func (m *model) setMode(mode appMode) tea.Cmd {
 	}
 	m.focus = NewFocusMap(items)
 	m.ui.focusIndex = m.focus.Index()
+	m.help.Blur()
 	return nil
 }
 

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"time"
 )
 
 // topicAtPosition returns the index of the topic chip located at the
@@ -48,7 +49,16 @@ func (m *model) startHistoryFilter() tea.Cmd {
 	for _, t := range m.topics.items {
 		topics = append(topics, t.title)
 	}
-	hf := newHistoryFilterForm(topics)
+	var topic string
+	var start, end time.Time
+	if m.history.filterQuery != "" {
+		ts, s, e, _ := parseHistoryQuery(m.history.filterQuery)
+		if len(ts) > 0 {
+			topic = ts[0]
+		}
+		start, end = s, e
+	}
+	hf := newHistoryFilterForm(topics, topic, start, end)
 	m.history.filterForm = &hf
 	return m.setMode(modeHistoryFilter)
 }

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -57,6 +57,9 @@ func (m *model) startHistoryFilter() tea.Cmd {
 			topic = ts[0]
 		}
 		start, end = s, e
+	} else {
+		end = time.Now()
+		start = end.Add(-time.Hour)
 	}
 	hf := newHistoryFilterForm(topics, topic, start, end)
 	m.history.filterForm = &hf

--- a/update.go
+++ b/update.go
@@ -618,6 +618,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		nm, cmd := m.updateImporter(msg)
 		*m = nm
 		return m, cmd
+	case modeHistoryFilter:
+		nm, cmd := m.updateHistoryFilter(msg)
+		*m = nm
+		return m, cmd
 	case modeHelp:
 		nm, cmd := m.updateHelp(msg)
 		*m = nm

--- a/update.go
+++ b/update.go
@@ -539,6 +539,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.ui.viewport.ScrollDown(1)
 			return m, nil
 		case "tab":
+			if m.currentMode() == modeHistoryFilter {
+				nm, cmd := m.updateHistoryFilter(msg)
+				*m = nm
+				return m, cmd
+			}
 			if len(m.ui.focusOrder) > 0 {
 				m.focus.Next()
 				m.ui.focusIndex = m.focus.Index()
@@ -555,6 +560,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case "shift+tab":
+			if m.currentMode() == modeHistoryFilter {
+				nm, cmd := m.updateHistoryFilter(msg)
+				*m = nm
+				return m, cmd
+			}
 			if len(m.ui.focusOrder) > 0 {
 				m.focus.Prev()
 				m.ui.focusIndex = m.focus.Index()
@@ -571,7 +581,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		}
-		if (msg.String() == "enter" || msg.String() == " " || msg.String() == "space") &&
+		if m.currentMode() != modeHistoryFilter &&
+			(msg.String() == "enter" || msg.String() == " " || msg.String() == "space") &&
 			m.help.Focused() {
 			cmd := m.setMode(modeHelp)
 			return m, cmd

--- a/update.go
+++ b/update.go
@@ -107,7 +107,6 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 		m.history.store.Add(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false})
 	}
 	if !m.history.showArchived {
-		m.history.items = append(m.history.items, hi)
 		if m.history.filterQuery != "" {
 			topics, start, end, pf := parseHistoryQuery(m.history.filterQuery)
 			var msgs []Message
@@ -117,12 +116,16 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 				msgs = m.history.store.Search(topics, start, end, pf)
 			}
 			items := make([]list.Item, len(msgs))
+			m.history.items = make([]historyItem, len(msgs))
 			for i, mmsg := range msgs {
-				items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+				hi := historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+				items[i] = hi
+				m.history.items[i] = hi
 			}
 			m.history.list.SetItems(items)
 			m.history.list.Select(len(items) - 1)
 		} else {
+			m.history.items = append(m.history.items, hi)
 			items := make([]list.Item, len(m.history.items))
 			for i, it := range m.history.items {
 				items[i] = it

--- a/update.go
+++ b/update.go
@@ -572,7 +572,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if (msg.String() == "enter" || msg.String() == " " || msg.String() == "space") &&
-			m.ui.focusOrder[m.ui.focusIndex] == idHelp {
+			m.help.Focused() {
 			cmd := m.setMode(modeHelp)
 			return m, cmd
 		}

--- a/update_client.go
+++ b/update_client.go
@@ -135,9 +135,18 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 			m.history.filterQuery = ""
 			m.history.list.FilterInput.SetValue("")
 			m.history.list.SetFilterState(list.Unfiltered)
-			items := make([]list.Item, len(m.history.items))
-			for i, it := range m.history.items {
-				items[i] = it
+			var msgs []Message
+			if m.history.showArchived {
+				msgs = m.history.store.SearchArchived(nil, time.Time{}, time.Time{}, "")
+			} else {
+				msgs = m.history.store.Search(nil, time.Time{}, time.Time{}, "")
+			}
+			m.history.items = make([]historyItem, len(msgs))
+			items := make([]list.Item, len(msgs))
+			for i, mm := range msgs {
+				hi := historyItem{timestamp: mm.Timestamp, topic: mm.Topic, payload: mm.Payload, kind: mm.Kind, archived: mm.Archived}
+				m.history.items[i] = hi
+				items[i] = hi
 			}
 			m.history.list.SetItems(items)
 		}

--- a/update_client.go
+++ b/update_client.go
@@ -130,6 +130,17 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 				cmds = append(cmds, cmd)
 			}
 		}
+	case "ctrl+f":
+		if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+			m.history.filterQuery = ""
+			m.history.list.FilterInput.SetValue("")
+			m.history.list.SetFilterState(list.Unfiltered)
+			items := make([]list.Item, len(m.history.items))
+			for i, it := range m.history.items {
+				items[i] = it
+			}
+			m.history.list.SetItems(items)
+		}
 	case "space":
 		if m.ui.focusOrder[m.ui.focusIndex] == idHistory && !m.history.showArchived {
 			idx := m.history.list.Index()
@@ -598,10 +609,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 	if st := m.history.list.FilterState(); st == list.Filtering || st == list.FilterApplied {
 		q := m.history.list.FilterInput.Value()
 		topics, start, end, text := parseHistoryQuery(q)
-		if start.IsZero() && end.IsZero() {
-			end = time.Now()
-			start = end.Add(-time.Hour)
-		}
+		m.history.filterQuery = q
 		var msgs []Message
 		if m.history.showArchived {
 			msgs = m.history.store.SearchArchived(topics, start, end, text)

--- a/update_client.go
+++ b/update_client.go
@@ -621,6 +621,19 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
 		}
 		m.history.list.SetItems(items)
+	} else if m.history.filterQuery != "" {
+		topics, start, end, text := parseHistoryQuery(m.history.filterQuery)
+		var msgs []Message
+		if m.history.showArchived {
+			msgs = m.history.store.SearchArchived(topics, start, end, text)
+		} else {
+			msgs = m.history.store.Search(topics, start, end, text)
+		}
+		items := make([]list.Item, len(msgs))
+		for i, mmsg := range msgs {
+			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+		}
+		m.history.list.SetItems(items)
 	} else {
 		items := make([]list.Item, len(m.history.items))
 		for i, it := range m.history.items {

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -33,8 +33,11 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 				msgs = m.history.store.Search(topics, start, end, payload)
 			}
 			items := make([]list.Item, len(msgs))
+			m.history.items = make([]historyItem, len(msgs))
 			for i, mmsg := range msgs {
-				items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+				hi := historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+				items[i] = hi
+				m.history.items[i] = hi
 			}
 			m.history.list.SetItems(items)
 			m.history.list.FilterInput.SetValue("")

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -17,7 +17,13 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 		switch t.String() {
 		case "esc":
 			m.history.filterForm = nil
-			cmd := m.setMode(m.previousMode())
+			if len(m.ui.modeStack) > 0 {
+				m.ui.modeStack = m.ui.modeStack[1:]
+			}
+			if len(m.ui.modeStack) > 0 && m.ui.modeStack[0] == modeHelp {
+				m.ui.modeStack = m.ui.modeStack[1:]
+			}
+			cmd := m.setMode(m.currentMode())
 			return m, cmd
 		case "enter":
 			q := m.history.filterForm.query()

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"time"
-
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -28,10 +26,6 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 		case "enter":
 			q := m.history.filterForm.query()
 			topics, start, end, _ := parseHistoryQuery(q)
-			if start.IsZero() && end.IsZero() {
-				end = time.Now()
-				start = end.Add(-time.Hour)
-			}
 			var msgs []Message
 			if m.history.showArchived {
 				msgs = m.history.store.SearchArchived(topics, start, end, "")
@@ -44,7 +38,12 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			}
 			m.history.list.SetItems(items)
 			m.history.list.FilterInput.SetValue(q)
-			m.history.list.SetFilterState(list.FilterApplied)
+			if q == "" {
+				m.history.list.SetFilterState(list.Unfiltered)
+			} else {
+				m.history.list.SetFilterState(list.FilterApplied)
+			}
+			m.history.filterQuery = q
 			m.history.filterForm = nil
 			cmd := tea.Batch(m.setMode(m.previousMode()), m.setFocus(idHistory))
 			return m, cmd

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -25,12 +25,12 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			return m, cmd
 		case "enter":
 			q := m.history.filterForm.query()
-			topics, start, end, _ := parseHistoryQuery(q)
+			topics, start, end, payload := parseHistoryQuery(q)
 			var msgs []Message
 			if m.history.showArchived {
-				msgs = m.history.store.SearchArchived(topics, start, end, "")
+				msgs = m.history.store.SearchArchived(topics, start, end, payload)
 			} else {
-				msgs = m.history.store.Search(topics, start, end, "")
+				msgs = m.history.store.Search(topics, start, end, payload)
 			}
 			items := make([]list.Item, len(msgs))
 			for i, mmsg := range msgs {

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -23,7 +23,7 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			if len(m.ui.modeStack) > 0 && m.ui.modeStack[0] == modeHelp {
 				m.ui.modeStack = m.ui.modeStack[1:]
 			}
-			cmd := m.setMode(m.currentMode())
+			cmd := tea.Batch(m.setMode(m.currentMode()), m.setFocus(idHistory))
 			return m, cmd
 		case "enter":
 			q := m.history.filterForm.query()
@@ -46,7 +46,7 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			m.history.list.FilterInput.SetValue(q)
 			m.history.list.SetFilterState(list.FilterApplied)
 			m.history.filterForm = nil
-			cmd := m.setMode(m.previousMode())
+			cmd := tea.Batch(m.setMode(m.previousMode()), m.setFocus(idHistory))
 			return m, cmd
 		}
 	}

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -37,12 +37,8 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 				items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
 			}
 			m.history.list.SetItems(items)
-			m.history.list.FilterInput.SetValue(q)
-			if q == "" {
-				m.history.list.SetFilterState(list.Unfiltered)
-			} else {
-				m.history.list.SetFilterState(list.FilterApplied)
-			}
+			m.history.list.FilterInput.SetValue("")
+			m.history.list.SetFilterState(list.Unfiltered)
 			m.history.filterQuery = q
 			m.history.filterForm = nil
 			cmd := tea.Batch(m.setMode(m.previousMode()), m.setFocus(idHistory))

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"time"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// updateHistoryFilter handles the history filter form interaction.
+func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
+	if m.history.filterForm == nil {
+		return m, nil
+	}
+	switch t := msg.(type) {
+	case tea.KeyMsg:
+		switch t.String() {
+		case "esc":
+			m.history.filterForm = nil
+			cmd := m.setMode(m.previousMode())
+			return m, cmd
+		case "enter":
+			q := m.history.filterForm.query()
+			topics, start, end, _ := parseHistoryQuery(q)
+			if start.IsZero() && end.IsZero() {
+				end = time.Now()
+				start = end.Add(-time.Hour)
+			}
+			var msgs []Message
+			if m.history.showArchived {
+				msgs = m.history.store.SearchArchived(topics, start, end, "")
+			} else {
+				msgs = m.history.store.Search(topics, start, end, "")
+			}
+			items := make([]list.Item, len(msgs))
+			for i, mmsg := range msgs {
+				items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
+			}
+			m.history.list.SetItems(items)
+			m.history.list.FilterInput.SetValue(q)
+			m.history.list.SetFilterState(list.FilterApplied)
+			m.history.filterForm = nil
+			cmd := m.setMode(m.previousMode())
+			return m, cmd
+		}
+	}
+	f, cmd := m.history.filterForm.Update(msg)
+	m.history.filterForm = &f
+	return m, cmd
+}

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -27,3 +27,32 @@ func TestUpdateHistoryFilter(t *testing.T) {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}
 }
+
+// Test that filtered results persist after the next update cycle.
+func TestHistoryFilterPersists(t *testing.T) {
+	m := initialModel(nil)
+	hs := &HistoryStore{}
+	m.history.store = hs
+	ts := time.Now()
+	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Add(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+
+	m.startHistoryFilter()
+	m.history.filterForm.topic.SetValue("foo")
+	m.history.filterForm.start.SetValue("")
+	m.history.filterForm.end.SetValue("")
+	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
+	m = &mv
+
+	// simulate a subsequent update
+	m.updateClient(nil)
+
+	items := m.history.list.Items()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item after update, got %d", len(items))
+	}
+	hi := items[0].(historyItem)
+	if hi.topic != "foo" {
+		t.Fatalf("unexpected topic %q", hi.topic)
+	}
+}

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that applying history filters populates the list with results.
+func TestUpdateHistoryFilter(t *testing.T) {
+	m := initialModel(nil)
+	hs := &HistoryStore{}
+	m.history.store = hs
+	ts := time.Now()
+	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+
+	m.startHistoryFilter()
+	m.history.filterForm.topic.SetValue("foo")
+	m.history.filterForm.start.SetValue("")
+	m.history.filterForm.end.SetValue("")
+	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
+	m = &mv
+
+	items := m.history.list.Items()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+}

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -22,9 +23,11 @@ func TestUpdateHistoryFilter(t *testing.T) {
 	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
 	m = &mv
 
-	items := m.history.list.Items()
-	if len(items) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(items))
+	if len(m.history.list.Items()) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(m.history.list.Items()))
+	}
+	if len(m.history.items) != 1 {
+		t.Fatalf("expected history.items to contain 1 item, got %d", len(m.history.items))
 	}
 }
 
@@ -51,8 +54,34 @@ func TestHistoryFilterPersists(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item after update, got %d", len(items))
 	}
+	if len(m.history.items) != 1 {
+		t.Fatalf("history.items length = %d, want 1", len(m.history.items))
+	}
 	hi := items[0].(historyItem)
 	if hi.topic != "foo" {
 		t.Fatalf("unexpected topic %q", hi.topic)
+	}
+}
+
+// Test that filtering updates the history label counts.
+func TestHistoryFilterUpdatesCounts(t *testing.T) {
+	m := initialModel(nil)
+	hs := &HistoryStore{}
+	m.history.store = hs
+	ts := time.Now()
+	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Add(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+
+	m.startHistoryFilter()
+	m.history.filterForm.topic.SetValue("foo")
+	m.history.filterForm.start.SetValue("")
+	m.history.filterForm.end.SetValue("")
+	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
+	m = &mv
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+
+	view := m.viewClient()
+	if !strings.Contains(view, "History (1/2 messages") {
+		t.Fatalf("expected count in label, got %q", view)
 	}
 }

--- a/views.go
+++ b/views.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/marang/goemqutiti/ui"
 )
@@ -173,7 +174,10 @@ func (m *model) viewClient() string {
 	}
 	histContent := m.history.list.View()
 	if m.history.filterQuery != "" {
-		histContent = fmt.Sprintf("Filters: %s\n%s", m.history.filterQuery, histContent)
+		inner := m.ui.width - 4
+		filterLine := fmt.Sprintf("Filters: %s", m.history.filterQuery)
+		filterLine = ansi.Truncate(filterLine, inner, "")
+		histContent = fmt.Sprintf("%s\n%s", filterLine, histContent)
 	}
 	messagesBox := ui.LegendBox(histContent, histLabel, m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused, histSP)
 

--- a/views.go
+++ b/views.go
@@ -164,6 +164,9 @@ func (m *model) viewClient() string {
 	}
 	msgCount := len(m.history.items)
 	histLabel := fmt.Sprintf("History (%d messages \u2013 Ctrl+C copy)", msgCount)
+	if m.history.filterQuery != "" {
+		histLabel += " [" + m.history.filterQuery + "]"
+	}
 	messagesBox := ui.LegendBox(m.history.list.View(), histLabel, m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused, histSP)
 
 	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)

--- a/views.go
+++ b/views.go
@@ -232,6 +232,16 @@ func (m model) viewConfirmDelete() string {
 	return lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box)
 }
 
+// viewHistoryFilter displays the history filter form.
+func (m model) viewHistoryFilter() string {
+	m.ui.elemPos = map[string]int{}
+	if m.history.filterForm == nil {
+		return ""
+	}
+	box := ui.LegendBox(m.history.filterForm.View(), "Filter", m.ui.width/2, 0, ui.ColBlue, true, -1)
+	return lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box)
+}
+
 // viewTopics displays the topic manager list.
 func (m model) viewTopics() string {
 	m.ui.elemPos = map[string]int{}
@@ -358,6 +368,8 @@ func (m *model) View() string {
 		return m.viewTraceMessages()
 	case modeImporter:
 		return m.viewImporter()
+	case modeHistoryFilter:
+		return m.viewHistoryFilter()
 	case modeHelp:
 		return m.viewHelp()
 	default:

--- a/views.go
+++ b/views.go
@@ -153,17 +153,24 @@ func (m *model) viewClient() string {
 	messageBox := ui.LegendBox(msgContent, "Message (Ctrl+S publishes)", m.ui.width-2, msgHeight, ui.ColBlue, messageFocused, msgSP)
 	// Calculate scroll percent for the history list
 	per := m.history.list.Paginator.PerPage
-	total := len(m.history.list.Items())
+	totalItems := len(m.history.list.Items())
 	histSP := -1.0
-	if total > per {
+	if totalItems > per {
 		start := m.history.list.Paginator.Page * per
-		denom := total - per
+		denom := totalItems - per
 		if denom > 0 {
 			histSP = float64(start) / float64(denom)
 		}
 	}
-	msgCount := len(m.history.items)
-	histLabel := fmt.Sprintf("History (%d messages \u2013 Ctrl+C copy)", msgCount)
+	total := len(m.history.items)
+	if m.history.store != nil {
+		total = m.history.store.Count(m.history.showArchived)
+	}
+	shown := len(m.history.items)
+	histLabel := fmt.Sprintf("History (%d messages \u2013 Ctrl+C copy)", total)
+	if m.history.filterQuery != "" && shown != total {
+		histLabel = fmt.Sprintf("History (%d/%d messages \u2013 Ctrl+C copy)", shown, total)
+	}
 	histContent := m.history.list.View()
 	if m.history.filterQuery != "" {
 		histContent = fmt.Sprintf("Filters: %s\n%s", m.history.filterQuery, histContent)

--- a/views.go
+++ b/views.go
@@ -228,6 +228,7 @@ func (m model) viewConfirmDelete() string {
 	if m.confirmInfo != "" {
 		content = lipgloss.JoinVertical(lipgloss.Left, m.confirmPrompt, m.confirmInfo)
 	}
+	content = lipgloss.NewStyle().Padding(1, 2).Render(content)
 	box := ui.LegendBox(content, "Confirm", m.ui.width/2, 0, ui.ColBlue, true, -1)
 	return lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box)
 }
@@ -238,7 +239,8 @@ func (m model) viewHistoryFilter() string {
 	if m.history.filterForm == nil {
 		return ""
 	}
-	box := ui.LegendBox(m.history.filterForm.View(), "Filter", m.ui.width/2, 0, ui.ColBlue, true, -1)
+	content := lipgloss.NewStyle().Padding(1, 2).Render(m.history.filterForm.View())
+	box := ui.LegendBox(content, "Filter", m.ui.width/2, 0, ui.ColBlue, true, -1)
 	return lipgloss.Place(m.ui.width, m.ui.height, lipgloss.Center, lipgloss.Center, box)
 }
 

--- a/views.go
+++ b/views.go
@@ -172,6 +172,11 @@ func (m *model) viewClient() string {
 	if m.history.filterQuery != "" && shown != total {
 		histLabel = fmt.Sprintf("History (%d/%d messages \u2013 Ctrl+C copy)", shown, total)
 	}
+	listHeight := m.layout.history.height
+	if m.history.filterQuery != "" && listHeight > 0 {
+		listHeight--
+	}
+	m.history.list.SetSize(m.ui.width-4, listHeight)
 	histContent := m.history.list.View()
 	if m.history.filterQuery != "" {
 		inner := m.ui.width - 4

--- a/views.go
+++ b/views.go
@@ -164,10 +164,11 @@ func (m *model) viewClient() string {
 	}
 	msgCount := len(m.history.items)
 	histLabel := fmt.Sprintf("History (%d messages \u2013 Ctrl+C copy)", msgCount)
+	histContent := m.history.list.View()
 	if m.history.filterQuery != "" {
-		histLabel += " [" + m.history.filterQuery + "]"
+		histContent = fmt.Sprintf("Filters: %s\n%s", m.history.filterQuery, histContent)
 	}
-	messagesBox := ui.LegendBox(m.history.list.View(), histLabel, m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused, histSP)
+	messagesBox := ui.LegendBox(histContent, histLabel, m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused, histSP)
 
 	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)
 


### PR DESCRIPTION
## Summary
- keep history list filtered after applying search
- default history results to last hour unless start/end specified
- document history filter tokens and default time window

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ca34e30408324bf03818834aeae3d