### PR TITLE
Remove debug prints from Connections.Update

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -57,17 +56,8 @@ func (m Connections) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if m.Focused {
-			// Handle key events when focused
-			switch msg.String() {
-			case "a": // Add new connection
-				m.TextInput.Focus()
-				log.Println("Add new connection")
-			case "e": // Edit selected connection
-				log.Println("Edit selected connection")
-			case "delete": // Delete selected connection
-				log.Println("Delete selected connection")
-			}
+		if m.Focused && msg.String() == "a" {
+			m.TextInput.Focus()
 		}
 	}
 	m.ConnectionsList, cmd = m.ConnectionsList.Update(msg)

--- a/connections.go
+++ b/connections.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -61,11 +62,11 @@ func (m Connections) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "a": // Add new connection
 				m.TextInput.Focus()
-				fmt.Println("Add new connection")
+				log.Println("Add new connection")
 			case "e": // Edit selected connection
-				fmt.Println("Edit selected connection")
+				log.Println("Edit selected connection")
 			case "delete": // Delete selected connection
-				fmt.Println("Delete selected connection")
+				log.Println("Delete selected connection")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- swap fmt prints in connection manager for standard log output to avoid raw stdout text

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d0ded2d648324b2547019a390dce6