### PR TITLE
Inline profile config into main package

### DIFF
--- a/connection_profile.go
+++ b/connection_profile.go
@@ -1,4 +1,4 @@
-package config
+package main
 
 import (
 	"fmt"

--- a/connectionform.go
+++ b/connectionform.go
@@ -6,7 +6,6 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/marang/goemqutiti/config"
 	"github.com/marang/goemqutiti/ui"
 )
 
@@ -51,7 +50,7 @@ const (
 // idx is -1 when creating a new profile.
 func newConnectionForm(p Profile, idx int) connectionForm {
 	if p.FromEnv {
-		config.ApplyEnvVars(&p)
+		ApplyEnvVars(&p)
 	}
 	pwKey := ""
 	if p.Name != "" && p.Username != "" {
@@ -254,7 +253,7 @@ func (f connectionForm) View() string {
 		s += fmt.Sprintf("%s: %s\n", label, in.View())
 	}
 	if chk, ok := f.fields[idxFromEnv].(*checkField); ok && chk.value {
-		prefix := config.EnvPrefix(f.fields[idxName].Value())
+		prefix := EnvPrefix(f.fields[idxName].Value())
 		s += ui.InfoStyle.Render("Values loaded from env vars: "+prefix+"<FIELD>") + "\n"
 	}
 	s += "\n" + ui.InfoStyle.Render("[enter] save  [esc] cancel")

--- a/connections.go
+++ b/connections.go
@@ -11,11 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/zalando/go-keyring"
-
-	"github.com/marang/goemqutiti/config"
 )
-
-type Profile = config.Profile
 
 // Connections manages the state and logic for handling broker profiles.
 type Connections struct {
@@ -61,11 +57,8 @@ func (m Connections) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "a": // Add new connection
 				m.TextInput.Focus()
-				fmt.Println("Add new connection")
 			case "e": // Edit selected connection
-				fmt.Println("Edit selected connection")
 			case "delete": // Delete selected connection
-				fmt.Println("Delete selected connection")
 			}
 		}
 	}
@@ -191,10 +184,9 @@ func (m *Connections) savePasswordToKeyring(service, username, password string) 
 	}
 }
 
-// LoadFromConfig loads connection profiles from the config file using the
-// shared config package.
+// LoadFromConfig loads connection profiles from the config file.
 func LoadFromConfig(filePath string) (*Connections, error) {
-	cfg, err := config.LoadConfig(filePath)
+	cfg, err := LoadConfig(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-
-	"github.com/marang/goemqutiti/config"
 )
 
 var (
@@ -100,37 +98,12 @@ func main() {
 // runImport launches the interactive import wizard using the provided file
 // path and profile name.
 func runImport(path, profile string) {
-	conns := NewConnectionsModel()
-	if err := conns.LoadProfiles(""); err != nil {
-		fmt.Println("Error loading profiles:", err)
+	p, err := LoadProfile(profile, "")
+	if err != nil {
+		fmt.Println("Error loading profile:", err)
 		return
 	}
-	var p *Profile
-	if profile != "" {
-		for i := range conns.Profiles {
-			if conns.Profiles[i].Name == profile {
-				p = &conns.Profiles[i]
-				break
-			}
-		}
-	} else if conns.DefaultProfileName != "" {
-		for i := range conns.Profiles {
-			if conns.Profiles[i].Name == conns.DefaultProfileName {
-				p = &conns.Profiles[i]
-				break
-			}
-		}
-	}
-	if p == nil && len(conns.Profiles) > 0 {
-		p = &conns.Profiles[0]
-	}
-	if p == nil {
-		fmt.Println("no connection profile available")
-		return
-	}
-	if p.FromEnv {
-		config.ApplyEnvVars(p)
-	} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
+	if env := os.Getenv("MQTT_PASSWORD"); env != "" && !p.FromEnv {
 		p.Password = env
 	}
 

--- a/model_init.go
+++ b/model_init.go
@@ -13,7 +13,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/marang/goemqutiti/config"
 	"github.com/marang/goemqutiti/ui"
 )
 
@@ -228,7 +227,7 @@ func initialModel(conns *Connections) *model {
 		if p != nil {
 			cfg := *p
 			if cfg.FromEnv {
-				config.ApplyEnvVars(&cfg)
+				ApplyEnvVars(&cfg)
 			} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 				cfg.Password = env
 			}

--- a/model_traces.go
+++ b/model_traces.go
@@ -6,20 +6,18 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
-
-	"github.com/marang/goemqutiti/config"
 )
 
 // forceStartTrace launches the tracer at index without checking existing data.
 func (m *model) forceStartTrace(index int) {
 	item := m.traces.items[index]
-	p, err := config.LoadProfile(item.cfg.Profile, "")
+	p, err := LoadProfile(item.cfg.Profile, "")
 	if err != nil {
 		m.appendHistory("", err.Error(), "log", err.Error())
 		return
 	}
 	if p.FromEnv {
-		config.ApplyEnvVars(p)
+		ApplyEnvVars(p)
 	} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 		p.Password = env
 	}

--- a/state.go
+++ b/state.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/marang/goemqutiti/config"
 )
 
 // persistedTopic mirrors topicItem for persistence in the config file.
@@ -43,7 +42,7 @@ type userConfig struct {
 
 // loadState retrieves saved topics and payloads from config.toml.
 func loadState() map[string]connectionData {
-	fp, err := config.DefaultUserConfigFile()
+	fp, err := DefaultUserConfigFile()
 	if err != nil {
 		return map[string]connectionData{}
 	}
@@ -68,7 +67,7 @@ func loadState() map[string]connectionData {
 
 // writeConfig writes the entire configuration back to disk.
 func writeConfig(cfg userConfig) {
-	fp, err := config.DefaultUserConfigFile()
+	fp, err := DefaultUserConfigFile()
 	if err != nil {
 		return
 	}
@@ -82,7 +81,7 @@ func writeConfig(cfg userConfig) {
 
 // saveState updates only the Saved section in config.toml.
 func saveState(data map[string]connectionData) {
-	fp, err := config.DefaultUserConfigFile()
+	fp, err := DefaultUserConfigFile()
 	if err != nil {
 		return
 	}
@@ -105,7 +104,7 @@ func saveState(data map[string]connectionData) {
 
 // loadTraces retrieves planned traces from config.toml.
 func loadTraces() map[string]TracerConfig {
-	fp, err := config.DefaultUserConfigFile()
+	fp, err := DefaultUserConfigFile()
 	if err != nil {
 		return map[string]TracerConfig{}
 	}
@@ -129,7 +128,7 @@ func loadTraces() map[string]TracerConfig {
 
 // saveTraces updates the Traces section in config.toml.
 func saveTraces(data map[string]TracerConfig) {
-	fp, err := config.DefaultUserConfigFile()
+	fp, err := DefaultUserConfigFile()
 	if err != nil {
 		return
 	}

--- a/tracer_headless.go
+++ b/tracer_headless.go
@@ -9,15 +9,13 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-
-	"github.com/marang/goemqutiti/config"
 )
 
 // mqttClient wraps the MQTT connection for the tracer.
 type mqttClient struct{ client mqtt.Client }
 
 // newMQTTClient establishes an MQTT connection using the provided profile.
-func newMQTTClient(p config.Profile) (*mqttClient, error) {
+func newMQTTClient(p Profile) (*mqttClient, error) {
 	opts := mqtt.NewClientOptions()
 	brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
 	opts.AddBroker(brokerURL)
@@ -102,7 +100,7 @@ func tracerRun(key, topics, profileName, startStr, endStr string) error {
 			return fmt.Errorf("invalid end time: %w", err)
 		}
 	}
-	p, err := config.LoadProfile(profileName, "")
+	p, err := LoadProfile(profileName, "")
 	if err != nil {
 		return err
 	}

--- a/update.go
+++ b/update.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-
-	"github.com/marang/goemqutiti/config"
 )
 
 type statusMessage string
@@ -248,7 +246,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					}
 					flushStatus(m.connections.statusChan)
 					if p.FromEnv {
-						config.ApplyEnvVars(&p)
+						ApplyEnvVars(&p)
 					} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 						p.Password = env
 					}
@@ -296,7 +294,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 				}
 				flushStatus(m.connections.statusChan)
 				if p.FromEnv {
-					config.ApplyEnvVars(&p)
+					ApplyEnvVars(&p)
 				} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 					p.Password = env
 				}

--- a/update_tracer.go
+++ b/update_tracer.go
@@ -7,8 +7,6 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-
-	"github.com/marang/goemqutiti/config"
 )
 
 type traceTickMsg struct{}
@@ -127,13 +125,13 @@ func (m model) updateTraceForm(msg tea.Msg) (model, tea.Cmd) {
 				m.traces.form.errMsg = "trace key exists"
 				return m, nil
 			}
-			p, err := config.LoadProfile(cfg.Profile, "")
+			p, err := LoadProfile(cfg.Profile, "")
 			if err != nil {
 				m.traces.form.errMsg = err.Error()
 				return m, nil
 			}
 			if p.FromEnv {
-				config.ApplyEnvVars(p)
+				ApplyEnvVars(p)
 			} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 				p.Password = env
 			}


### PR DESCRIPTION
## Summary
- inline profile configuration helpers into connection_profile.go
- update call sites to use LoadProfile directly
- drop stray debug Println from connections manager

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d0dc2754883248d3dd2775f956773