### PR TITLE
Handle profile cleanup errors

### DIFF
--- a/connection_profile.go
+++ b/connection_profile.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -303,10 +305,22 @@ func savePasswordToKeyring(service, username, password string) {
 	}
 }
 
-// deleteProfileData removes profile-specific persisted history and traces.
-func deleteProfileData(name string) {
-	os.RemoveAll(filepath.Join(files.DataDir(name), "history"))
-	os.RemoveAll(filepath.Join(files.DataDir(name), "traces"))
+// deleteProfileData removes profile-specific persisted history and traces and
+// returns any cleanup errors.
+func deleteProfileData(name string) error {
+	historyPath := filepath.Join(files.DataDir(name), "history")
+	historyErr := os.RemoveAll(historyPath)
+	if historyErr != nil {
+		log.Printf("Error removing %s: %v", historyPath, historyErr)
+	}
+
+	tracesPath := filepath.Join(files.DataDir(name), "traces")
+	tracesErr := os.RemoveAll(tracesPath)
+	if tracesErr != nil {
+		log.Printf("Error removing %s: %v", tracesPath, tracesErr)
+	}
+
+	return errors.Join(historyErr, tracesErr)
 }
 
 // persistProfileChange applies a profile update, saves config and keyring.

--- a/connections.go
+++ b/connections.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -102,7 +103,9 @@ func (m *Connections) DeleteConnection(index int) {
 		delete(m.Errors, name)
 		// Persist removal so the connection no longer appears after a restart
 		saveConfig(m.Profiles, m.DefaultProfileName)
-		deleteProfileData(name)
+		if err := deleteProfileData(name); err != nil {
+			log.Printf("Failed to remove data for profile %s: %v", name, err)
+		}
 		m.refreshList()
 	}
 }


### PR DESCRIPTION
## Summary
- return an error from `deleteProfileData` and log failures deleting history or traces
- warn when connection data cleanup fails during `DeleteConnection`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d25c912248324aebc3043b656946b