### PR TITLE
Centralize MQTT password overrides

### DIFF
--- a/config/override_test.go
+++ b/config/override_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOverridePasswordFromEnv_FromEnv(t *testing.T) {
+	p := &Profile{Name: "demo", FromEnv: true}
+	os.Setenv("GOEMQUTITI_DEMO_PASSWORD", "envpass")
+	os.Setenv("MQTT_PASSWORD", "global")
+	defer os.Unsetenv("GOEMQUTITI_DEMO_PASSWORD")
+	defer os.Unsetenv("MQTT_PASSWORD")
+
+	OverridePasswordFromEnv(p)
+	if p.Password != "envpass" {
+		t.Fatalf("expected envpass, got %s", p.Password)
+	}
+}
+
+func TestOverridePasswordFromEnv_Global(t *testing.T) {
+	p := &Profile{Name: "demo"}
+	os.Setenv("MQTT_PASSWORD", "global")
+	defer os.Unsetenv("MQTT_PASSWORD")
+
+	OverridePasswordFromEnv(p)
+	if p.Password != "global" {
+		t.Fatalf("expected global, got %s", p.Password)
+	}
+}
+
+func TestOverridePasswordFromEnv_NoChange(t *testing.T) {
+	p := &Profile{Name: "demo", FromEnv: true}
+	os.Setenv("MQTT_PASSWORD", "global")
+	defer os.Unsetenv("MQTT_PASSWORD")
+
+	OverridePasswordFromEnv(p)
+	if p.Password != "" {
+		t.Fatalf("expected empty password, got %s", p.Password)
+	}
+}

--- a/config/profile.go
+++ b/config/profile.go
@@ -133,6 +133,16 @@ func ApplyEnvVars(p *Profile) {
 	}
 }
 
+// OverridePasswordFromEnv applies environment variables when FromEnv is set
+// and otherwise overrides the password using the MQTT_PASSWORD variable.
+func OverridePasswordFromEnv(p *Profile) {
+	if p.FromEnv {
+		ApplyEnvVars(p)
+	} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
+		p.Password = env
+	}
+}
+
 // LoadConfig reads profiles from a TOML file and resolves keyring references.
 func LoadConfig(filePath string) (*Config, error) {
 	var err error

--- a/main.go
+++ b/main.go
@@ -128,11 +128,7 @@ func runImport(path, profile string) {
 		fmt.Println("no connection profile available")
 		return
 	}
-	if p.FromEnv {
-		config.ApplyEnvVars(p)
-	} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
-		p.Password = env
-	}
+	config.OverridePasswordFromEnv(p)
 
 	client, err := NewMQTTClient(*p, nil)
 	if err != nil {

--- a/model_init.go
+++ b/model_init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -227,11 +226,7 @@ func initialModel(conns *Connections) *model {
 		}
 		if p != nil {
 			cfg := *p
-			if cfg.FromEnv {
-				config.ApplyEnvVars(&cfg)
-			} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
-				cfg.Password = env
-			}
+			config.OverridePasswordFromEnv(&cfg)
 			if client, err := NewMQTTClient(cfg, nil); err == nil {
 				m.mqttClient = client
 				m.connections.active = cfg.Name

--- a/model_traces.go
+++ b/model_traces.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -18,11 +17,7 @@ func (m *model) forceStartTrace(index int) {
 		m.appendHistory("", err.Error(), "log", err.Error())
 		return
 	}
-	if p.FromEnv {
-		config.ApplyEnvVars(p)
-	} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
-		p.Password = env
-	}
+	config.OverridePasswordFromEnv(p)
 	client, err := NewMQTTClient(*p, nil)
 	if err != nil {
 		m.appendHistory("", err.Error(), "log", err.Error())

--- a/override_call_test.go
+++ b/override_call_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marang/goemqutiti/config"
+)
+
+func TestOverridePasswordFromEnvCallSite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	data := `[[profiles]]
+name="demo"
+password="orig"
+`
+	if err := os.WriteFile(cfgPath, []byte(data), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	p, err := config.LoadProfile("demo", cfgPath)
+	if err != nil {
+		t.Fatalf("load profile: %v", err)
+	}
+	os.Setenv("MQTT_PASSWORD", "override")
+	defer os.Unsetenv("MQTT_PASSWORD")
+	config.OverridePasswordFromEnv(p)
+	if p.Password != "override" {
+		t.Fatalf("expected override, got %s", p.Password)
+	}
+}

--- a/tracer_headless.go
+++ b/tracer_headless.go
@@ -106,9 +106,7 @@ func tracerRun(key, topics, profileName, startStr, endStr string) error {
 	if err != nil {
 		return err
 	}
-	if env := os.Getenv("MQTT_PASSWORD"); env != "" && !p.FromEnv {
-		p.Password = env
-	}
+	config.OverridePasswordFromEnv(p)
 	client, err := newMQTTClient(*p)
 	if err != nil {
 		return fmt.Errorf("connect error: %w", err)

--- a/update.go
+++ b/update.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -247,11 +246,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 						return m, cmd
 					}
 					flushStatus(m.connections.statusChan)
-					if p.FromEnv {
-						config.ApplyEnvVars(&p)
-					} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
-						p.Password = env
-					}
+					config.OverridePasswordFromEnv(&p)
 					m.connections.manager.Errors[p.Name] = ""
 					m.connections.manager.Statuses[p.Name] = "connecting"
 					brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
@@ -295,11 +290,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					return m, cmd
 				}
 				flushStatus(m.connections.statusChan)
-				if p.FromEnv {
-					config.ApplyEnvVars(&p)
-				} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
-					p.Password = env
-				}
+				config.OverridePasswordFromEnv(&p)
 				m.connections.manager.Errors[p.Name] = ""
 				m.connections.manager.Statuses[p.Name] = "connecting"
 				brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)

--- a/update_tracer.go
+++ b/update_tracer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -132,11 +131,7 @@ func (m model) updateTraceForm(msg tea.Msg) (model, tea.Cmd) {
 				m.traces.form.errMsg = err.Error()
 				return m, nil
 			}
-			if p.FromEnv {
-				config.ApplyEnvVars(p)
-			} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
-				p.Password = env
-			}
+			config.OverridePasswordFromEnv(p)
 			client, err := NewMQTTClient(*p, nil)
 			if err != nil {
 				m.traces.form.errMsg = err.Error()


### PR DESCRIPTION
## Summary
- add `config.OverridePasswordFromEnv` to apply per-profile env vars or `MQTT_PASSWORD`
- use helper across connection and tracing code to remove duplicated password checks
- test env password override behavior at package and call-site levels

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d0e177ed88324bef77334ad71c045