### PR TITLE
Surface connection form validation errors

### DIFF
--- a/mqttclient.go
+++ b/mqttclient.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -38,10 +39,12 @@ func NewMQTTClient(p Profile, statusChan chan string) (*MQTTClient, error) {
 	}
 
 	if p.MQTTVersion != "" {
-		var ver uint
-		fmt.Sscan(p.MQTTVersion, &ver)
+		ver, err := strconv.Atoi(p.MQTTVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MQTT version %q: %w", p.MQTTVersion, err)
+		}
 		if ver != 0 {
-			opts.SetProtocolVersion(ver)
+			opts.SetProtocolVersion(uint(ver))
 		}
 	}
 	if p.ConnectTimeout > 0 {

--- a/tracer_headless.go
+++ b/tracer_headless.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,10 +30,12 @@ func newMQTTClient(p Profile) (*mqttClient, error) {
 		opts.SetPassword(p.Password)
 	}
 	if p.MQTTVersion != "" {
-		var ver uint
-		fmt.Sscan(p.MQTTVersion, &ver)
+		ver, err := strconv.Atoi(p.MQTTVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MQTT version %q: %w", p.MQTTVersion, err)
+		}
 		if ver != 0 {
-			opts.SetProtocolVersion(ver)
+			opts.SetProtocolVersion(uint(ver))
 		}
 	}
 	if p.ConnectTimeout > 0 {

--- a/update.go
+++ b/update.go
@@ -354,7 +354,13 @@ func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
 			m.connections.form = nil
 			return m, cmd
 		case "enter":
-			p := m.connections.form.Profile()
+			p, err := m.connections.form.Profile()
+			if err != nil {
+				if m.connections.statusChan != nil {
+					m.connections.statusChan <- err.Error()
+				}
+				return m, listenStatus(m.connections.statusChan)
+			}
 			if m.connections.form.index >= 0 {
 				m.connections.manager.EditConnection(m.connections.form.index, p)
 			} else {


### PR DESCRIPTION
## Summary
- parse profile fields with `strconv` and aggregate validation errors
- propagate invalid profile data to the UI via status messages
- validate MQTT version strings when constructing clients
- restore the env checkbox and report status when parsing fails

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d25c010c4832481f0e75359e8ff7f