### PR TITLE
Switch env var prefix to EMQUTITI with legacy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ password = "keyring:emqutiti-local/user"
 Tips:
 - More options like TLS and session settings are available; see the `config` package for details.
 - Set `random_id_suffix = true` for unique client IDs.
-- Enable **Load from env** to read variables such as `GOEMQUTITI_LOCAL_BROKER_PASSWORD`.
+- Enable **Load from env** to read variables such as `EMQUTITI_LOCAL_BROKER_PASSWORD`.
 
 ### Shortcuts
 

--- a/config_state_test.go
+++ b/config_state_test.go
@@ -48,13 +48,13 @@ from_env = true
 	if err := os.WriteFile(cfg, []byte(data), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	os.Setenv("GOEMQUTITI_TEST_HOST", "example.com")
-	os.Setenv("GOEMQUTITI_TEST_PORT", "1884")
-	os.Setenv("GOEMQUTITI_TEST_SCHEMA", "ssl")
+	os.Setenv("EMQUTITI_TEST_HOST", "example.com")
+	os.Setenv("EMQUTITI_TEST_PORT", "1884")
+	os.Setenv("EMQUTITI_TEST_SCHEMA", "ssl")
 	defer func() {
-		os.Unsetenv("GOEMQUTITI_TEST_HOST")
-		os.Unsetenv("GOEMQUTITI_TEST_PORT")
-		os.Unsetenv("GOEMQUTITI_TEST_SCHEMA")
+		os.Unsetenv("EMQUTITI_TEST_HOST")
+		os.Unsetenv("EMQUTITI_TEST_PORT")
+		os.Unsetenv("EMQUTITI_TEST_SCHEMA")
 	}()
 
 	c, err := LoadFromConfig(cfg)

--- a/connection_profile.go
+++ b/connection_profile.go
@@ -96,7 +96,7 @@ func sanitizeEnvName(name string) string {
 
 // EnvPrefix returns the prefix used for environment variables derived from a
 // profile name.
-func EnvPrefix(name string) string { return "GOEMQUTITI_" + sanitizeEnvName(name) + "_" }
+func EnvPrefix(name string) string { return "EMQUTITI_" + sanitizeEnvName(name) + "_" }
 
 type profileEnvSetter func(*Profile, string)
 
@@ -208,9 +208,17 @@ func ApplyEnvVars(p *Profile) {
 		return
 	}
 	prefix := EnvPrefix(p.Name)
+	// For a limited time, also check the old GOEMQUTITI_ prefix for
+	// backward compatibility.
+	oldPrefix := "GO" + prefix
 	for tag, setter := range profileEnvSetters {
-		envName := prefix + strings.ToUpper(strings.ReplaceAll(tag, "-", "_"))
+		key := strings.ToUpper(strings.ReplaceAll(tag, "-", "_"))
+		envName := prefix + key
 		if val, ok := os.LookupEnv(envName); ok {
+			setter(p, val)
+			continue
+		}
+		if val, ok := os.LookupEnv(oldPrefix + key); ok {
 			setter(p, val)
 		}
 	}

--- a/connection_profile_test.go
+++ b/connection_profile_test.go
@@ -101,11 +101,11 @@ from_env = true
 	if err := keyring.Set("svc", "u1", "secret"); err != nil {
 		t.Fatalf("keyring set: %v", err)
 	}
-	os.Setenv("GOEMQUTITI_ENV_HOST", "example.com")
-	os.Setenv("GOEMQUTITI_ENV_PORT", "1884")
+	os.Setenv("EMQUTITI_ENV_HOST", "example.com")
+	os.Setenv("EMQUTITI_ENV_PORT", "1884")
 	t.Cleanup(func() {
-		os.Unsetenv("GOEMQUTITI_ENV_HOST")
-		os.Unsetenv("GOEMQUTITI_ENV_PORT")
+		os.Unsetenv("EMQUTITI_ENV_HOST")
+		os.Unsetenv("EMQUTITI_ENV_PORT")
 	})
 
 	cfg, err := LoadConfig(cfgPath)

--- a/connectionform_test.go
+++ b/connectionform_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 func TestNewConnectionFormEnvReadOnly(t *testing.T) {
-	os.Setenv("GOEMQUTITI_ENV_HOST", "envhost")
-	os.Setenv("GOEMQUTITI_ENV_PORT", "1884")
+	os.Setenv("EMQUTITI_ENV_HOST", "envhost")
+	os.Setenv("EMQUTITI_ENV_PORT", "1884")
 	t.Cleanup(func() {
-		os.Unsetenv("GOEMQUTITI_ENV_HOST")
-		os.Unsetenv("GOEMQUTITI_ENV_PORT")
+		os.Unsetenv("EMQUTITI_ENV_HOST")
+		os.Unsetenv("EMQUTITI_ENV_PORT")
 	})
 	cf := newConnectionForm(Profile{Name: "env", FromEnv: true}, 0)
 	hostField, ok := cf.fields[fieldIndex["Host"]].(*textField)
@@ -62,7 +62,7 @@ func TestConnectionFormProfile(t *testing.T) {
 	cf.fields[fieldIndex["AutoReconnect"]].(*checkField).value = true
 	cf.fields[fieldIndex["QoS"]].(*selectField).index = 2
 
-	p := cf.Profile()
+	p, _ := cf.Profile()
 	if p.Name != "n1" || p.Port != 1883 || !p.AutoReconnect || p.QoS != 2 {
 		t.Fatalf("unexpected profile: %#v", p)
 	}
@@ -71,7 +71,7 @@ func TestConnectionFormProfile(t *testing.T) {
 func TestConnectionFormProfileInvalidInt(t *testing.T) {
 	cf := newConnectionForm(Profile{}, -1)
 	cf.fields[fieldIndex["Port"]].(*textField).SetValue("abc")
-	p := cf.Profile()
+	p, _ := cf.Profile()
 	if p.Port != 0 {
 		t.Fatalf("expected port 0, got %d", p.Port)
 	}


### PR DESCRIPTION
## Summary
- change EnvPrefix to use `EMQUTITI_` and fall back to `GOEMQUTITI_`
- update tests and docs to the new prefix

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d485616488324b72dabd0008b73fe