### PR TITLE
refactor: use logging and return errors

### DIFF
--- a/connection_profile.go
+++ b/connection_profile.go
@@ -307,10 +307,8 @@ func saveConfig(profiles []Profile, defaultName string) {
 }
 
 // savePasswordToKeyring stores a password in the system keyring.
-func savePasswordToKeyring(service, username, password string) {
-	if err := keyring.Set("emqutiti-"+service, username, password); err != nil {
-		fmt.Println("Error saving password to keyring:", err)
-	}
+func savePasswordToKeyring(service, username, password string) error {
+	return keyring.Set("emqutiti-"+service, username, password)
 }
 
 // deleteProfileData removes profile-specific persisted history and traces and
@@ -332,7 +330,7 @@ func deleteProfileData(name string) error {
 }
 
 // persistProfileChange applies a profile update, saves config and keyring.
-func persistProfileChange(profiles *[]Profile, defaultName string, p Profile, idx int) {
+func persistProfileChange(profiles *[]Profile, defaultName string, p Profile, idx int) error {
 	plain := p.Password
 	if !p.FromEnv {
 		p.Password = "keyring:emqutiti-" + p.Name + "/" + p.Username
@@ -346,6 +344,9 @@ func persistProfileChange(profiles *[]Profile, defaultName string, p Profile, id
 	}
 	saveConfig(*profiles, defaultName)
 	if !p.FromEnv {
-		savePasswordToKeyring(p.Name, p.Username, plain)
+		if err := savePasswordToKeyring(p.Name, p.Username, plain); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/connection_profile_test.go
+++ b/connection_profile_test.go
@@ -143,7 +143,9 @@ password = "keyring:svc/u1"
 
 func TestSavePasswordToKeyring(t *testing.T) {
 	keyring.MockInit()
-	savePasswordToKeyring("svc", "user", "pw")
+	if err := savePasswordToKeyring("svc", "user", "pw"); err != nil {
+		t.Fatalf("savePasswordToKeyring: %v", err)
+	}
 	got, err := keyring.Get("emqutiti-svc", "user")
 	if err != nil || got != "pw" {
 		t.Fatalf("got %q err %v", got, err)
@@ -197,7 +199,9 @@ func TestPersistProfileChange(t *testing.T) {
 
 	profiles := []Profile{}
 	p := Profile{Name: "test", Username: "user", Password: "secret"}
-	persistProfileChange(&profiles, "test", p, -1)
+	if err := persistProfileChange(&profiles, "test", p, -1); err != nil {
+		t.Fatalf("persistProfileChange: %v", err)
+	}
 
 	if len(profiles) != 1 {
 		t.Fatalf("expected 1 profile, got %d", len(profiles))

--- a/connections.go
+++ b/connections.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -71,7 +70,9 @@ func (m *Connections) AddConnection(p Profile) {
 		m.Errors = make(map[string]string)
 	}
 	m.Errors[p.Name] = ""
-	persistProfileChange(&m.Profiles, m.DefaultProfileName, p, -1)
+	if err := persistProfileChange(&m.Profiles, m.DefaultProfileName, p, -1); err != nil {
+		log.Printf("Failed to persist profile %s: %v", p.Name, err)
+	}
 	m.refreshList()
 }
 
@@ -89,7 +90,9 @@ func (m *Connections) EditConnection(index int, p Profile) {
 				m.Errors[p.Name] = errMsg
 			}
 		}
-		persistProfileChange(&m.Profiles, m.DefaultProfileName, p, index)
+		if err := persistProfileChange(&m.Profiles, m.DefaultProfileName, p, index); err != nil {
+			log.Printf("Failed to persist profile %s: %v", p.Name, err)
+		}
 		m.refreshList()
 	}
 }
@@ -135,7 +138,7 @@ func LoadFromConfig(filePath string) (*Connections, error) {
 func (c *Connections) LoadProfiles(filePath string) error {
 	loaded, err := LoadFromConfig(filePath)
 	if err != nil {
-		fmt.Println("Warning:", err)
+		log.Printf("Warning: %v", err)
 		return err
 	}
 	c.DefaultProfileName = loaded.DefaultProfileName

--- a/focus_test.go
+++ b/focus_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 // Test that setFocus correctly focuses the message input
 func TestSetFocusMessage(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	if m.message.input.Focused() {
 		t.Fatalf("message input should start blurred")
 	}
@@ -20,7 +20,7 @@ func TestSetFocusMessage(t *testing.T) {
 // Test that pressing Tab cycles focus from topic to message
 // Test that pressing Tab cycles focus from topics to topic input
 func TestTabCyclesToTopic(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	if m.focus.Index() != 0 {
 		t.Fatalf("initial focus index should be 0")
 	}

--- a/help_test.go
+++ b/help_test.go
@@ -8,7 +8,7 @@ import (
 
 // Test that pressing enter with the help icon focused opens the help view.
 func TestEnterOpensHelp(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.setFocus(idHelp)
 	if m.ui.focusOrder[m.focus.Index()] != idHelp {
 		t.Fatalf("help not focused")
@@ -27,7 +27,7 @@ func TestEnterOpensHelp(t *testing.T) {
 
 // Test that space also opens help when focused.
 func TestSpaceOpensHelp(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.setFocus(idHelp)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
 	if cmd != nil {
@@ -40,7 +40,7 @@ func TestSpaceOpensHelp(t *testing.T) {
 
 // Test that Esc exits help even after pressing enter again in help mode.
 func TestEscFromHelpAfterEnter(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.setFocus(idHelp)
 	m.Update(tea.KeyMsg{Type: tea.KeyEnter}) // open help
 	if m.currentMode() != modeHelp {

--- a/history_select_test.go
+++ b/history_select_test.go
@@ -10,7 +10,7 @@ import (
 
 // Test that ctrl+a toggles history selection
 func TestCtrlATogglesHistorySelection(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.history.items = []historyItem{
 		{timestamp: time.Now(), topic: "t1", payload: "p1", kind: "pub"},
 		{timestamp: time.Now(), topic: "t2", payload: "p2", kind: "pub"},

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -13,7 +13,7 @@ import (
 
 // Test that historyDelegate renders lines that fit the list width
 func TestHistoryDelegateWidth(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	d := historyDelegate{m: m}
 	m.history.list.SetSize(30, 4)
 	hi := historyItem{timestamp: time.Now(), topic: "foo", payload: "bar", kind: "pub"}
@@ -29,7 +29,7 @@ func TestHistoryDelegateWidth(t *testing.T) {
 
 // Test that the history box has aligned borders when rendered
 func TestHistoryBoxLayout(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
 	m.appendHistory("foo", "bar", "pub", "")
 	view := m.viewClient()
@@ -60,7 +60,7 @@ func TestHistoryBoxLayout(t *testing.T) {
 
 // Test that active filters are shown inside the history box rather than in the border.
 func TestHistoryFilterDisplayedInsideBox(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.history.filterQuery = "topic=foo"
 	m.history.store = &HistoryStore{}
 	m.appendHistory("foo", "bar", "pub", "")
@@ -100,7 +100,7 @@ func TestHistoryFilterDisplayedInsideBox(t *testing.T) {
 
 // Test that the history label reports total and filtered message counts.
 func TestHistoryLabelCounts(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.history.store = &HistoryStore{}
 	m.appendHistory("foo", "bar", "pub", "")
 	m.appendHistory("bar", "baz", "sub", "")
@@ -129,7 +129,7 @@ func TestHistoryLabelCounts(t *testing.T) {
 
 // Test that a long filter query does not break the history box layout.
 func TestHistoryFilterLineWidth(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	long := strings.Repeat("x", 100)
 	m.history.filterQuery = "topic=" + long
 	m.history.store = &HistoryStore{}
@@ -163,7 +163,7 @@ func TestHistoryFilterLineWidth(t *testing.T) {
 
 // Test that the history help legend remains visible after applying a filter.
 func TestHistoryHelpVisibleWithFilter(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.history.store = &HistoryStore{}
 	m.history.filterQuery = "topic=foo"
 	m.appendHistory("foo", "bar", "pub", "")

--- a/model_init.go
+++ b/model_init.go
@@ -17,7 +17,7 @@ import (
 )
 
 // initialModel creates the main program model with optional connection data.
-func initialModel(conns *Connections) *model {
+func initialModel(conns *Connections) (*model, error) {
 	ti := textinput.New()
 	ti.Placeholder = "Enter Topic"
 	ti.Focus()
@@ -49,12 +49,13 @@ func initialModel(conns *Connections) *model {
 	ta.BlurredStyle.CursorLine = ui.BlurredStyle
 
 	var connModel Connections
+	var loadErr error
 	if conns != nil {
 		connModel = *conns
 	} else {
 		connModel = NewConnectionsModel()
 		if err := connModel.LoadProfiles(""); err != nil {
-			fmt.Println("Warning:", err)
+			loadErr = err
 		}
 	}
 	connModel.ConnectionsList.SetShowStatusBar(false)
@@ -237,12 +238,12 @@ func initialModel(conns *Connections) *model {
 				m.importWizard = NewImportWizard(client, importFile)
 				m.setMode(modeImporter)
 			} else {
-				fmt.Println("connect error:", err)
+				return nil, fmt.Errorf("connect error: %w", err)
 			}
 		}
 	}
 	m.rebuildActiveTopicList()
-	return m
+	return m, loadErr
 }
 
 // Init enables initial Tea behavior such as mouse support.

--- a/topic_delete_test.go
+++ b/topic_delete_test.go
@@ -8,7 +8,7 @@ import (
 
 // Test that deleting a topic via confirmation removes it from the list
 func TestDeleteTopic(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.topics.items = []topicItem{{title: "a", subscribed: true}, {title: "b", subscribed: false}}
 	m.setFocus(idTopics)
 	m.topics.selected = 0

--- a/topic_mouse_test.go
+++ b/topic_mouse_test.go
@@ -27,7 +27,7 @@ func setupTopics(m *model) {
 }
 
 func TestMouseToggleFirstTopic(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupTopics(m)
 	m.viewClient()
@@ -50,7 +50,7 @@ func TestMouseToggleFirstTopic(t *testing.T) {
 }
 
 func TestMouseToggleThirdRowTopic(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupTopics(m)
 	m.viewClient()
@@ -74,7 +74,7 @@ func TestMouseToggleThirdRowTopic(t *testing.T) {
 }
 
 func TestMouseToggleFourthRowTopic(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupTopics(m)
 	m.viewClient()
@@ -107,7 +107,7 @@ func setupManyTopics(m *model, n int) {
 
 func TestMouseToggleFifteenthRowTopic(t *testing.T) {
 	for offset := 0; offset < lipgloss.Height(ui.ChipStyle.Render("test")); offset++ {
-		m := initialModel(nil)
+		m, _ := initialModel(nil)
 		m.Update(tea.WindowSizeMsg{Width: 40, Height: 80})
 		setupManyTopics(m, 50)
 		m.viewClient()
@@ -135,7 +135,7 @@ func TestMouseToggleFifteenthRowTopic(t *testing.T) {
 
 func TestMouseToggleWithScroll(t *testing.T) {
 	for offset := 0; offset < lipgloss.Height(ui.ChipStyle.Render("test")); offset++ {
-		m := initialModel(nil)
+		m, _ := initialModel(nil)
 		// Small height so we need to scroll to reach later rows
 		m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
 		setupManyTopics(m, 30)

--- a/topic_publish_test.go
+++ b/topic_publish_test.go
@@ -8,7 +8,7 @@ import (
 
 // Test that pressing enter in the topic input subscribes to that topic
 func TestEnterAddsTopic(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.topics.input.SetValue("foo")
 	m.setFocus(idTopic)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -22,7 +22,7 @@ func TestEnterAddsTopic(t *testing.T) {
 
 // Test that ctrl+s publishes the message in the editor
 func TestCtrlSPublishesMessage(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.topics.items = []topicItem{{title: "foo", subscribed: true}}
 	m.message.input.SetValue("hello")
 	m.setFocus(idMessage)

--- a/topic_scroll_test.go
+++ b/topic_scroll_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTopicsScrollDown(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupManyTopics(m, 10)
 	m.layout.topics.height = 2
@@ -26,7 +26,7 @@ func TestTopicsScrollDown(t *testing.T) {
 }
 
 func TestTopicsScrollDownJ(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupManyTopics(m, 10)
 	m.layout.topics.height = 2
@@ -43,7 +43,7 @@ func TestTopicsScrollDownJ(t *testing.T) {
 }
 
 func TestTopicSelectionScroll(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupManyTopics(m, 10)
 	m.layout.topics.height = 2

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -10,7 +10,7 @@ import (
 
 // Test that applying history filters populates the list with results.
 func TestUpdateHistoryFilter(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	hs := &HistoryStore{}
 	m.history.store = hs
 	ts := time.Now()
@@ -33,7 +33,7 @@ func TestUpdateHistoryFilter(t *testing.T) {
 
 // Test that filtered results persist after the next update cycle.
 func TestHistoryFilterPersists(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	hs := &HistoryStore{}
 	m.history.store = hs
 	ts := time.Now()
@@ -65,7 +65,7 @@ func TestHistoryFilterPersists(t *testing.T) {
 
 // Test that filtering updates the history label counts.
 func TestHistoryFilterUpdatesCounts(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	hs := &HistoryStore{}
 	m.history.store = hs
 	ts := time.Now()

--- a/viewport_scroll_test.go
+++ b/viewport_scroll_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestViewportScrollCtrlJ(t *testing.T) {
-	m := initialModel(nil)
+	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
 	for i := 0; i < 50; i++ {
 		m.appendHistory("t", "msg", "pub", "")


### PR DESCRIPTION
## Summary
- replace fmt.Println with log or error returns
- propagate keyring and initialization errors
- drop file-based logging and return import errors

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d509cfff48324a5840afd281e3c63