### PR TITLE
Add tests for client and importer

### DIFF
--- a/importer_wizard_test.go
+++ b/importer_wizard_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type mockPublisher struct{}
+
+func (m *mockPublisher) Publish(topic string, qos byte, retained bool, payload interface{}) error {
+	return nil
+}
+
+// Test wizard progresses through file, map, template, and publish steps.
+func TestImportWizardStepProgression(t *testing.T) {
+	f, err := os.CreateTemp("", "wiz-*.csv")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("a,b\n1,2\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	w := NewImportWizard(&mockPublisher{}, f.Name())
+
+	if w.step != stepFile {
+		t.Fatalf("expected stepFile, got %d", w.step)
+	}
+	w.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if w.step != stepMap {
+		t.Fatalf("expected stepMap, got %d", w.step)
+	}
+	w.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if w.step != stepTemplate {
+		t.Fatalf("expected stepTemplate, got %d", w.step)
+	}
+	w.tmpl.SetValue("topic/{a}")
+	w.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if w.step != stepReview {
+		t.Fatalf("expected stepReview, got %d", w.step)
+	}
+	_, cmd := w.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if w.step != stepPublish {
+		t.Fatalf("expected stepPublish, got %d", w.step)
+	}
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			switch m := msg.(type) {
+			case tea.BatchMsg:
+				for _, c := range m {
+					if c != nil {
+						if mm := c(); mm != nil {
+							w.Update(mm)
+						}
+					}
+				}
+			default:
+				w.Update(msg)
+			}
+		}
+	}
+	if w.index != 1 {
+		t.Fatalf("expected index 1 after first publish, got %d", w.index)
+	}
+}

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test copy behavior when history items are selected.
+func TestHandleClientKeyCopySelected(t *testing.T) {
+	m := initialModel(nil)
+	sel := true
+	hi := historyItem{topic: "t1", payload: "msg1", kind: "pub", isSelected: &sel}
+	m.history.items = []historyItem{hi}
+	m.history.list.SetItems([]list.Item{hi})
+	m.history.list.Select(0)
+
+	m.handleClientKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+
+	if len(m.history.items) != 2 {
+		t.Fatalf("expected error appended to history, got %d items", len(m.history.items))
+	}
+	if m.history.items[1].kind != "log" {
+		t.Fatalf("expected last item kind 'log', got %q", m.history.items[1].kind)
+	}
+}
+
+// Test disconnect behavior clears connection state.
+func TestHandleClientKeyDisconnect(t *testing.T) {
+	conn := NewConnectionsModel()
+	conn.Profiles = []Profile{{Name: "test"}}
+	conn.Statuses["test"] = "connected"
+	conn.Errors["test"] = "oops"
+
+	m := initialModel(&conn)
+	m.mqttClient = &MQTTClient{}
+	m.connections.connection = "test"
+	m.connections.active = "test"
+	m.connections.manager.Statuses["test"] = "connected"
+	m.connections.manager.Errors["test"] = "boom"
+
+	m.handleClientKey(tea.KeyMsg{Type: tea.KeyCtrlX})
+
+	if m.mqttClient != nil {
+		t.Fatalf("expected mqttClient nil after disconnect")
+	}
+	if m.connections.connection != "" || m.connections.active != "" {
+		t.Fatalf("expected connection cleared, got %q %q", m.connections.connection, m.connections.active)
+	}
+	if st := m.connections.manager.Statuses["test"]; st != "disconnected" {
+		t.Fatalf("expected status 'disconnected', got %q", st)
+	}
+	if err := m.connections.manager.Errors["test"]; err != "" {
+		t.Fatalf("expected error cleared, got %q", err)
+	}
+}
+
+// Test that pressing '/' while history is focused starts the filter form.
+func TestHandleClientKeyFilterInitiation(t *testing.T) {
+	m := initialModel(nil)
+	idx := 3 // history index in focus order
+	m.focus.Set(idx)
+	m.ui.focusIndex = idx
+
+	m.handleClientKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+	if m.ui.modeStack[0] != modeHistoryFilter {
+		t.Fatalf("expected modeHistoryFilter, got %v", m.ui.modeStack[0])
+	}
+	if m.history.filterForm == nil {
+		t.Fatalf("expected filter form to be initialized")
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage for copy, disconnect, and filter commands in client
- ensure importer wizard steps from file to publish

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d50b7b97c8324a955b85bc705825f