### PR TITLE
profile: add BrokerURL helper

### DIFF
--- a/connection_profile.go
+++ b/connection_profile.go
@@ -47,6 +47,11 @@ type Profile struct {
 	RandomIDSuffix      bool   `toml:"random_id_suffix"`
 }
 
+// BrokerURL returns the formatted broker URL.
+func (p Profile) BrokerURL() string {
+	return fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+}
+
 type Config struct {
 	DefaultProfile string    `toml:"default_profile"`
 	Profiles       []Profile `toml:"profiles"`

--- a/connection_profile_test.go
+++ b/connection_profile_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/marang/goemqutiti/internal/files"
 )
 
+func TestProfileBrokerURL(t *testing.T) {
+	p := Profile{Schema: "mqtt", Host: "example.com", Port: 1883}
+	if got := p.BrokerURL(); got != "mqtt://example.com:1883" {
+		t.Fatalf("BrokerURL() = %q", got)
+	}
+}
+
 // TestApplyEnvVars sets env vars for all Profile fields and ensures they are applied.
 func TestApplyEnvVars(t *testing.T) {
 	p := Profile{Name: "test", FromEnv: true}

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -25,8 +25,7 @@ type MQTTClient struct {
 // details. The status channel receives connection status updates.
 func NewMQTTClient(p Profile, statusChan chan string) (*MQTTClient, error) {
 	opts := mqtt.NewClientOptions()
-	brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
-	opts.AddBroker(brokerURL)
+	opts.AddBroker(p.BrokerURL())
 	cid := p.ClientID
 	if p.RandomIDSuffix {
 		cid = fmt.Sprintf("%s-%d", cid, time.Now().UnixNano())

--- a/tracer_headless.go
+++ b/tracer_headless.go
@@ -18,8 +18,7 @@ type mqttClient struct{ client mqtt.Client }
 // newMQTTClient establishes an MQTT connection using the provided profile.
 func newMQTTClient(p Profile) (*mqttClient, error) {
 	opts := mqtt.NewClientOptions()
-	brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
-	opts.AddBroker(brokerURL)
+	opts.AddBroker(p.BrokerURL())
 	cid := p.ClientID
 	if p.RandomIDSuffix {
 		cid = fmt.Sprintf("%s-%d", cid, time.Now().UnixNano())

--- a/update.go
+++ b/update.go
@@ -71,7 +71,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case connectResult:
-		brokerURL := fmt.Sprintf("%s://%s:%d", msg.profile.Schema, msg.profile.Host, msg.profile.Port)
+		brokerURL := msg.profile.BrokerURL()
 		if msg.err != nil {
 			m.connections.manager.Statuses[msg.profile.Name] = "disconnected"
 			m.connections.manager.Errors[msg.profile.Name] = fmt.Sprintf("Failed to connect to %s: %v", brokerURL, msg.err)
@@ -112,7 +112,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 				if i >= 0 && i < len(m.connections.manager.Profiles) {
 					p := m.connections.manager.Profiles[i]
 					if p.Name == m.connections.active && m.connections.manager.Statuses[p.Name] == "connected" {
-						brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+						brokerURL := p.BrokerURL()
 						m.connections.connection = "Connected to " + brokerURL
 						m.connections.manager.Errors[p.Name] = ""
 						m.refreshConnectionItems()
@@ -127,7 +127,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					}
 					m.connections.manager.Errors[p.Name] = ""
 					m.connections.manager.Statuses[p.Name] = "connecting"
-					brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+					brokerURL := p.BrokerURL()
 					m.connections.connection = "Connecting to " + brokerURL
 					m.refreshConnectionItems()
 					return m, connectBroker(p, m.connections.statusChan)
@@ -160,7 +160,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			if i >= 0 && i < len(m.connections.manager.Profiles) {
 				p := m.connections.manager.Profiles[i]
 				if p.Name == m.connections.active && m.connections.manager.Statuses[p.Name] == "connected" {
-					brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+					brokerURL := p.BrokerURL()
 					m.connections.connection = "Connected to " + brokerURL
 					m.connections.manager.Errors[p.Name] = ""
 					m.refreshConnectionItems()
@@ -175,7 +175,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 				}
 				m.connections.manager.Errors[p.Name] = ""
 				m.connections.manager.Statuses[p.Name] = "connecting"
-				brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+				brokerURL := p.BrokerURL()
 				m.connections.connection = "Connecting to " + brokerURL
 				m.refreshConnectionItems()
 				return m, connectBroker(p, m.connections.statusChan)

--- a/update_connection.go
+++ b/update_connection.go
@@ -18,7 +18,7 @@ type connectResult struct {
 func connectBroker(p Profile, ch chan string) tea.Cmd {
 	return func() tea.Msg {
 		if ch != nil {
-			brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+			brokerURL := p.BrokerURL()
 			ch <- fmt.Sprintf("Connecting to %s", brokerURL)
 		}
 		client, err := NewMQTTClient(p, ch)


### PR DESCRIPTION
## Summary
- add Profile.BrokerURL to centralize broker URL formatting
- switch existing code to use BrokerURL
- cover BrokerURL with unit test

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d5b78107c8324bfd292b9ece05e94