### PR TITLE
Add history detail view for long payloads

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // handleCopyKey copies selected or current history items to the clipboard.
@@ -83,4 +84,23 @@ func (m *model) handleClearFilterKey() tea.Cmd {
 	}
 	m.history.list.SetItems(items)
 	return nil
+}
+
+// handleHistoryViewKey opens a detail view for long history payloads.
+func (m *model) handleHistoryViewKey() tea.Cmd {
+	if m.ui.focusOrder[m.ui.focusIndex] != idHistory {
+		return nil
+	}
+	idx := m.history.list.Index()
+	if idx < 0 || idx >= len(m.history.list.Items()) {
+		return nil
+	}
+	hi := m.history.list.Items()[idx].(historyItem)
+	if lipgloss.Width(hi.payload) <= historyPreviewLimit {
+		return nil
+	}
+	m.history.detailItem = hi
+	m.history.detail.SetContent(hi.payload)
+	m.history.detail.SetYOffset(0)
+	return m.setMode(modeHistoryDetail)
 }

--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -35,9 +35,10 @@ func (m *model) handleTopicScroll(key string) tea.Cmd {
 	return nil
 }
 
-// handleEnterKey handles Enter for topic input and toggling.
+// handleEnterKey handles Enter for topic input, toggling, and history detail.
 func (m *model) handleEnterKey() tea.Cmd {
-	if m.ui.focusOrder[m.ui.focusIndex] == idTopic {
+	switch m.ui.focusOrder[m.ui.focusIndex] {
+	case idTopic:
 		topic := strings.TrimSpace(m.topics.input.Value())
 		if topic != "" && !m.hasTopic(topic) {
 			m.topics.items = append(m.topics.items, topicItem{title: topic, subscribed: true})
@@ -51,12 +52,16 @@ func (m *model) handleEnterKey() tea.Cmd {
 			m.appendHistory(topic, "", "log", fmt.Sprintf("Subscribed to topic: %s", topic))
 			m.topics.input.SetValue("")
 		}
-	} else if m.ui.focusOrder[m.ui.focusIndex] == idTopics && m.topics.selected >= 0 && m.topics.selected < len(m.topics.items) {
-		m.toggleTopic(m.topics.selected)
-		m.ensureTopicVisible()
-		if m.currentMode() == modeTopics {
-			m.rebuildActiveTopicList()
+	case idTopics:
+		if m.topics.selected >= 0 && m.topics.selected < len(m.topics.items) {
+			m.toggleTopic(m.topics.selected)
+			m.ensureTopicVisible()
+			if m.currentMode() == modeTopics {
+				m.rebuildActiveTopicList()
+			}
 		}
+	case idHistory:
+		return m.handleHistoryViewKey()
 	}
 	return nil
 }

--- a/history_delegate.go
+++ b/history_delegate.go
@@ -13,6 +13,8 @@ import (
 	"github.com/marang/goemqutiti/ui"
 )
 
+const historyPreviewLimit = 256
+
 // historyDelegate renders history items with two lines and supports highlighting
 // selected entries.
 type historyDelegate struct{ m *model }
@@ -66,7 +68,10 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		lines = append(lines, lipgloss.PlaceHorizontal(innerWidth, align, header))
 	}
 	first := strings.Split(hi.payload, "\n")[0]
-	more := strings.Contains(hi.payload, "\n")
+	more := strings.Contains(hi.payload, "\n") || lipgloss.Width(hi.payload) > historyPreviewLimit
+	if lipgloss.Width(first) > historyPreviewLimit {
+		first = ansi.Truncate(first, historyPreviewLimit, "")
+	}
 	trunc := ansi.Truncate(first, innerWidth, "")
 	if more || lipgloss.Width(first) > innerWidth {
 		if lipgloss.Width(trunc) >= innerWidth {

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -173,3 +173,18 @@ func TestHistoryHelpVisibleWithFilter(t *testing.T) {
 		t.Fatalf("expected history shortcuts in view, got %q", view)
 	}
 }
+
+// Test that triggering the detail view shows the complete payload.
+func TestHistoryDetailViewShowsPayload(t *testing.T) {
+	m, _ := initialModel(nil)
+	long := strings.Repeat("x", historyPreviewLimit+10)
+	m.appendHistory("foo", long, "pub", "")
+	m.setFocus(idHistory)
+	m.handleEnterKey()
+	if m.currentMode() != modeHistoryDetail {
+		t.Fatalf("expected detail mode, got %v", m.currentMode())
+	}
+	if m.history.detailItem.payload != long {
+		t.Fatalf("payload not preserved in detail view")
+	}
+}

--- a/model.go
+++ b/model.go
@@ -42,6 +42,7 @@ var focusByMode = map[appMode][]string{
 	modeViewTrace:      {idHelp},
 	modeImporter:       {idHelp},
 	modeHistoryFilter:  {idHelp},
+	modeHistoryDetail:  {idHelp},
 	modeHelp:           {idHelp},
 }
 
@@ -128,6 +129,7 @@ const (
 	modeViewTrace
 	modeImporter
 	modeHistoryFilter
+	modeHistoryDetail
 	modeHelp
 )
 
@@ -165,6 +167,8 @@ type historyState struct {
 	showArchived    bool
 	filterForm      *historyFilterForm
 	filterQuery     string
+	detail          viewport.Model
+	detailItem      historyItem
 }
 
 type paneState struct {

--- a/model_init.go
+++ b/model_init.go
@@ -126,6 +126,7 @@ func initialModel(conns *Connections) (*model, error) {
 			items:           []historyItem{},
 			store:           nil,
 			selectionAnchor: -1,
+			detail:          viewport.New(0, 0),
 		},
 		topics: topicsState{
 			input: ti,

--- a/update.go
+++ b/update.go
@@ -425,6 +425,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.traces.list.SetSize(msg.Width-4, msg.Height-4)
 		m.help.vp.Width = msg.Width - 4
 		m.help.vp.Height = msg.Height - 4
+		m.history.detail.Width = msg.Width - 4
+		m.history.detail.Height = msg.Height - 4
 		m.ui.viewport.Width = msg.Width
 		// Reserve two lines for the info header at the top of the view.
 		m.ui.viewport.Height = msg.Height - 2
@@ -530,6 +532,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	case modeHistoryFilter:
 		nm, cmd := m.updateHistoryFilter(msg)
+		*m = nm
+		return m, cmd
+	case modeHistoryDetail:
+		nm, cmd := m.updateHistoryDetail(msg)
 		*m = nm
 		return m, cmd
 	case modeHelp:

--- a/update_history_detail.go
+++ b/update_history_detail.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// updateHistoryDetail handles input when viewing a long history payload.
+func (m model) updateHistoryDetail(msg tea.Msg) (model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			cmd := m.setMode(modeClient)
+			return m, cmd
+		case "ctrl+d":
+			return m, tea.Quit
+		}
+	}
+	m.history.detail, cmd = m.history.detail.Update(msg)
+	return m, cmd
+}

--- a/views.go
+++ b/views.go
@@ -231,6 +231,21 @@ func (m model) viewTraceMessages() string {
 	return m.overlayHelp(view)
 }
 
+// viewHistoryDetail renders the full payload of a history message.
+func (m model) viewHistoryDetail() string {
+	m.ui.elemPos = map[string]int{}
+	lines := strings.Split(m.history.detail.View(), "\n")
+	help := ui.InfoStyle.Render("[esc] back")
+	lines = append(lines, help)
+	content := strings.Join(lines, "\n")
+	sp := -1.0
+	if m.history.detail.Height < lipgloss.Height(content) {
+		sp = m.history.detail.ScrollPercent()
+	}
+	view := ui.LegendBox(content, "Message", m.ui.width-2, m.ui.height-2, ui.ColGreen, true, sp)
+	return m.overlayHelp(view)
+}
+
 // viewImporter renders the importer wizard view.
 func (m model) viewImporter() string {
 	m.ui.elemPos = map[string]int{}
@@ -277,6 +292,8 @@ func (m *model) View() string {
 		return m.viewImporter()
 	case modeHistoryFilter:
 		return m.viewHistoryFilter()
+	case modeHistoryDetail:
+		return m.viewHistoryDetail()
 	case modeHelp:
 		return m.viewHelp()
 	default:


### PR DESCRIPTION
## Summary
- limit history previews to 256 characters
- open a history detail view for long messages and allow ESC to close
- test that the detail view shows the full payload

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d5b69f64c8324941612e40b8b0f33