### PR TITLE
Add message-to-history conversion helper

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -74,13 +74,8 @@ func (m *model) handleClearFilterKey() tea.Cmd {
 	} else {
 		msgs = m.history.store.Search(nil, time.Time{}, time.Time{}, "")
 	}
-	m.history.items = make([]historyItem, len(msgs))
-	items := make([]list.Item, len(msgs))
-	for i, mm := range msgs {
-		hi := historyItem{timestamp: mm.Timestamp, topic: mm.Topic, payload: mm.Payload, kind: mm.Kind, archived: mm.Archived}
-		m.history.items[i] = hi
-		items[i] = hi
-	}
+	var items []list.Item
+	m.history.items, items = messagesToHistoryItems(msgs)
 	m.history.list.SetItems(items)
 	return nil
 }

--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -18,13 +18,8 @@ func (m *model) handleToggleArchiveKey() tea.Cmd {
 		} else {
 			msgs = m.history.store.Search(nil, time.Time{}, time.Time{}, "")
 		}
-		m.history.items = make([]historyItem, len(msgs))
-		items := make([]list.Item, len(msgs))
-		for i, mm := range msgs {
-			hi := historyItem{timestamp: mm.Timestamp, topic: mm.Topic, payload: mm.Payload, kind: mm.Kind, archived: mm.Archived}
-			m.history.items[i] = hi
-			items[i] = hi
-		}
+		var items []list.Item
+		m.history.items, items = messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)
 		if len(items) > 0 {
 			m.history.list.Select(len(items) - 1)

--- a/history_util.go
+++ b/history_util.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/charmbracelet/bubbles/list"
+
+// messagesToHistoryItems converts a slice of messages into history items
+// and a matching slice of list items for use with the history list.
+func messagesToHistoryItems(msgs []Message) ([]historyItem, []list.Item) {
+	hitems := make([]historyItem, len(msgs))
+	litems := make([]list.Item, len(msgs))
+	for i, m := range msgs {
+		hi := historyItem{
+			timestamp: m.Timestamp,
+			topic:     m.Topic,
+			payload:   m.Payload,
+			kind:      m.Kind,
+			archived:  m.Archived,
+		}
+		hitems[i] = hi
+		litems[i] = hi
+	}
+	return hitems, litems
+}

--- a/history_util_test.go
+++ b/history_util_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMessagesToHistoryItems verifies conversion from Message slices to history items.
+func TestMessagesToHistoryItems(t *testing.T) {
+	msgs := []Message{
+		{Timestamp: time.Unix(0, 1), Topic: "t1", Payload: "p1", Kind: "pub", Archived: false},
+		{Timestamp: time.Unix(0, 2), Topic: "t2", Payload: "p2", Kind: "sub", Archived: true},
+	}
+	hitems, litems := messagesToHistoryItems(msgs)
+	if len(hitems) != len(msgs) {
+		t.Fatalf("history items len %d want %d", len(hitems), len(msgs))
+	}
+	if len(litems) != len(msgs) {
+		t.Fatalf("list items len %d want %d", len(litems), len(msgs))
+	}
+	for i, hi := range hitems {
+		m := msgs[i]
+		if hi.timestamp != m.Timestamp || hi.topic != m.Topic || hi.payload != m.Payload || hi.kind != m.Kind || hi.archived != m.Archived {
+			t.Fatalf("item %d mismatch: %#v vs %#v", i, hi, m)
+		}
+		if li, ok := litems[i].(historyItem); ok {
+			if li != hi {
+				t.Fatalf("list item %d mismatch: %#v vs %#v", i, li, hi)
+			}
+		} else {
+			t.Fatalf("list item %d has unexpected type %T", i, litems[i])
+		}
+	}
+}

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -113,13 +113,8 @@ func TestHistoryLabelCounts(t *testing.T) {
 	// apply filter showing only "foo"
 	m.history.filterQuery = "topic=foo"
 	msgs := m.history.store.Search([]string{"foo"}, time.Time{}, time.Time{}, "")
-	items := make([]list.Item, len(msgs))
-	m.history.items = make([]historyItem, len(msgs))
-	for i, mm := range msgs {
-		hi := historyItem{timestamp: mm.Timestamp, topic: mm.Topic, payload: mm.Payload, kind: mm.Kind, archived: mm.Archived}
-		items[i] = hi
-		m.history.items[i] = hi
-	}
+	var items []list.Item
+	m.history.items, items = messagesToHistoryItems(msgs)
 	m.history.list.SetItems(items)
 	view = m.viewClient()
 	if !strings.Contains(view, "History (1/2 messages") {

--- a/model_init.go
+++ b/model_init.go
@@ -196,12 +196,8 @@ func initialModel(conns *Connections) (*model, error) {
 	if idx, err := openHistoryStore(""); err == nil {
 		m.history.store = idx
 		msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
-		items := make([]list.Item, len(msgs))
-		for i, mmsg := range msgs {
-			hi := historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
-			items[i] = hi
-			m.history.items = append(m.history.items, hi)
-		}
+		var items []list.Item
+		m.history.items, items = messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)
 	}
 

--- a/update.go
+++ b/update.go
@@ -86,12 +86,8 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			if idx, err := openHistoryStore(msg.profile.Name); err == nil {
 				m.history.store = idx
 				msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
-				m.history.items = nil
-				items := make([]list.Item, len(msgs))
-				for i, mmsg := range msgs {
-					items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind}
-					m.history.items = append(m.history.items, items[i].(historyItem))
-				}
+				var items []list.Item
+				m.history.items, items = messagesToHistoryItems(msgs)
 				m.history.list.SetItems(items)
 			}
 			m.restoreState(msg.profile.Name)

--- a/update_client.go
+++ b/update_client.go
@@ -209,10 +209,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		} else {
 			msgs = m.history.store.Search(topics, start, end, text)
 		}
-		items := make([]list.Item, len(msgs))
-		for i, mmsg := range msgs {
-			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
-		}
+		_, items := messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)
 	} else if m.history.filterQuery != "" {
 		topics, start, end, text := parseHistoryQuery(m.history.filterQuery)
@@ -222,10 +219,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		} else {
 			msgs = m.history.store.Search(topics, start, end, text)
 		}
-		items := make([]list.Item, len(msgs))
-		for i, mmsg := range msgs {
-			items[i] = historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
-		}
+		_, items := messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)
 	} else {
 		items := make([]list.Item, len(m.history.items))

--- a/update_history.go
+++ b/update_history.go
@@ -48,13 +48,8 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 			} else {
 				msgs = m.history.store.Search(topics, start, end, pf)
 			}
-			items := make([]list.Item, len(msgs))
-			m.history.items = make([]historyItem, len(msgs))
-			for i, mmsg := range msgs {
-				hi := historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
-				items[i] = hi
-				m.history.items[i] = hi
-			}
+			var items []list.Item
+			m.history.items, items = messagesToHistoryItems(msgs)
 			m.history.list.SetItems(items)
 			m.history.list.Select(len(items) - 1)
 		} else {

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -32,13 +32,8 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			} else {
 				msgs = m.history.store.Search(topics, start, end, payload)
 			}
-			items := make([]list.Item, len(msgs))
-			m.history.items = make([]historyItem, len(msgs))
-			for i, mmsg := range msgs {
-				hi := historyItem{timestamp: mmsg.Timestamp, topic: mmsg.Topic, payload: mmsg.Payload, kind: mmsg.Kind, archived: mmsg.Archived}
-				items[i] = hi
-				m.history.items[i] = hi
-			}
+			var items []list.Item
+			m.history.items, items = messagesToHistoryItems(msgs)
 			m.history.list.SetItems(items)
 			m.history.list.FilterInput.SetValue("")
 			m.history.list.SetFilterState(list.Unfiltered)


### PR DESCRIPTION
## Summary
- add `messagesToHistoryItems` helper for converting `Message` slices into history items
- refactor history components to use the helper
- test helper conversion logic

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d5c9733e48324976cefdb4ff4ea4f