### PR TITLE
Fix history preview for short multiline messages

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -10,7 +10,6 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // handleCopyKey copies selected or current history items to the clipboard.

--- a/history_delegate.go
+++ b/history_delegate.go
@@ -68,7 +68,7 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 			lipgloss.NewStyle().Foreground(ui.ColGray).Render(" "+ts+":"))
 		lines = append(lines, lipgloss.PlaceHorizontal(innerWidth, align, header))
 	}
-	text := strings.ReplaceAll(hi.payload, "\n", " ")
+	text := strings.NewReplacer("\r\n", "\u23ce", "\n", "\u23ce", "\r", "\u23ce").Replace(hi.payload)
 	more := utf8.RuneCountInString(text) > historyPreviewLimit
 	if more {
 		text = ansi.Truncate(text, historyPreviewLimit, "")

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -39,8 +39,25 @@ func TestHistoryPreviewShortMultiline(t *testing.T) {
 	if strings.Contains(out, "\u2026") {
 		t.Fatalf("expected no ellipsis, got %q", out)
 	}
-	if !strings.Contains(out, "one two") {
-		t.Fatalf("expected joined payload, got %q", out)
+	if !strings.Contains(out, "one\u23cetwo") {
+		t.Fatalf("expected payload with line break marker, got %q", out)
+	}
+}
+
+// Test that short payloads with CRLF line endings are shown without truncation.
+func TestHistoryPreviewShortMultilineCRLF(t *testing.T) {
+	m, _ := initialModel(nil)
+	d := historyDelegate{m: m}
+	m.history.list.SetSize(80, 4)
+	hi := historyItem{timestamp: time.Now(), topic: "foo", payload: "one\r\ntwo", kind: "pub"}
+	var buf bytes.Buffer
+	d.Render(&buf, m.history.list, 0, hi)
+	out := buf.String()
+	if strings.Contains(out, "\u2026") {
+		t.Fatalf("expected no ellipsis, got %q", out)
+	}
+	if !strings.Contains(out, "one\u23cetwo") {
+		t.Fatalf("expected payload with line break marker, got %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- handle CRLF line endings when formatting history previews so short multiline messages aren't truncated
- display a line break marker instead of flattening newline characters
- add tests covering LF and CRLF payloads
- remove unused lipgloss import to satisfy `go vet`

## Testing
- `go vet ./...`
- `go test -count=1 ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d614eaf048324ae2921a788ec6341