### PR TITLE
Use pointer receivers for stateful updates

### DIFF
--- a/update.go
+++ b/update.go
@@ -50,16 +50,16 @@ func (m *model) updateConfirmDelete(msg tea.Msg) (model, tea.Cmd) {
 }
 
 // updateTopics manages the topics list UI.
-func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateTopics(msg tea.Msg) tea.Cmd {
 	var cmd, fcmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+d":
-			return m, tea.Quit
+			return tea.Quit
 		case "esc":
 			cmd := m.setMode(modeClient)
-			return m, cmd
+			return cmd
 		case "left":
 			if m.topics.panes.active == 1 {
 				fcmd = m.setFocus(idTopicsEnabled)
@@ -77,7 +77,7 @@ func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
 					m.removeTopic(i)
 					m.rebuildActiveTopicList()
 				})
-				return m, listenStatus(m.connections.statusChan)
+				return listenStatus(m.connections.statusChan)
 			}
 		case "enter", " ":
 			i := m.topics.selected
@@ -96,20 +96,20 @@ func (m model) updateTopics(msg tea.Msg) (model, tea.Cmd) {
 		m.topics.panes.unsubscribed.page = m.topics.list.Paginator.Page
 	}
 	m.topics.selected = m.indexForPane(m.topics.panes.active, m.topics.list.Index())
-	return m, tea.Batch(fcmd, cmd, listenStatus(m.connections.statusChan))
+	return tea.Batch(fcmd, cmd, listenStatus(m.connections.statusChan))
 }
 
 // updatePayloads manages the stored payloads list.
-func (m model) updatePayloads(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updatePayloads(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+d":
-			return m, tea.Quit
+			return tea.Quit
 		case "esc":
 			cmd := m.setMode(modeClient)
-			return m, cmd
+			return cmd
 		case "delete":
 			i := m.message.list.Index()
 			if i >= 0 {
@@ -120,7 +120,7 @@ func (m model) updatePayloads(msg tea.Msg) (model, tea.Cmd) {
 					m.message.list.SetItems(items)
 				}
 			}
-			return m, listenStatus(m.connections.statusChan)
+			return listenStatus(m.connections.statusChan)
 		case "enter":
 			i := m.message.list.Index()
 			if i >= 0 {
@@ -130,13 +130,13 @@ func (m model) updatePayloads(msg tea.Msg) (model, tea.Cmd) {
 					m.topics.input.SetValue(pi.topic)
 					m.message.input.SetValue(pi.payload)
 					cmd := m.setMode(modeClient)
-					return m, cmd
+					return cmd
 				}
 			}
 		}
 	}
 	m.message.list, cmd = m.message.list.Update(msg)
-	return m, tea.Batch(cmd, listenStatus(m.connections.statusChan))
+	return tea.Batch(cmd, listenStatus(m.connections.statusChan))
 }
 
 // updateSelectionRange selects history entries from the anchor to idx.
@@ -195,8 +195,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "tab":
 			if m.currentMode() == modeHistoryFilter {
-				nm, cmd := m.updateHistoryFilter(msg)
-				*m = nm
+				cmd := m.updateHistoryFilter(msg)
 				return m, cmd
 			}
 			if len(m.ui.focusOrder) > 0 {
@@ -216,8 +215,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "shift+tab":
 			if m.currentMode() == modeHistoryFilter {
-				nm, cmd := m.updateHistoryFilter(msg)
-				*m = nm
+				cmd := m.updateHistoryFilter(msg)
 				return m, cmd
 			}
 			if len(m.ui.focusOrder) > 0 {
@@ -249,48 +247,38 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmd := m.updateClient(msg)
 		return m, cmd
 	case modeConnections:
-		nm, cmd := m.updateConnections(msg)
-		*m = nm
+		cmd := m.updateConnections(msg)
 		return m, cmd
 	case modeEditConnection:
-		nm, cmd := m.updateForm(msg)
-		*m = nm
+		cmd := m.updateForm(msg)
 		return m, cmd
 	case modeConfirmDelete:
 		nm, cmd := m.updateConfirmDelete(msg)
 		*m = nm
 		return m, cmd
 	case modeTopics:
-		nm, cmd := m.updateTopics(msg)
-		*m = nm
+		cmd := m.updateTopics(msg)
 		return m, cmd
 	case modePayloads:
-		nm, cmd := m.updatePayloads(msg)
-		*m = nm
+		cmd := m.updatePayloads(msg)
 		return m, cmd
 	case modeTracer:
-		nm, cmd := m.updateTraces(msg)
-		*m = nm
+		cmd := m.updateTraces(msg)
 		return m, cmd
 	case modeEditTrace:
-		nm, cmd := m.updateTraceForm(msg)
-		*m = nm
+		cmd := m.updateTraceForm(msg)
 		return m, cmd
 	case modeViewTrace:
-		nm, cmd := m.updateTraceView(msg)
-		*m = nm
+		cmd := m.updateTraceView(msg)
 		return m, cmd
 	case modeImporter:
-		nm, cmd := m.updateImporter(msg)
-		*m = nm
+		cmd := m.updateImporter(msg)
 		return m, cmd
 	case modeHistoryFilter:
-		nm, cmd := m.updateHistoryFilter(msg)
-		*m = nm
+		cmd := m.updateHistoryFilter(msg)
 		return m, cmd
 	case modeHistoryDetail:
-		nm, cmd := m.updateHistoryDetail(msg)
-		*m = nm
+		cmd := m.updateHistoryDetail(msg)
 		return m, cmd
 	case modeHelp:
 		nm, cmd := m.updateHelp(msg)

--- a/update_connections.go
+++ b/update_connections.go
@@ -10,7 +10,7 @@ import (
 )
 
 // updateConnections processes input when the connections view is active.
-func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateConnections(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case connectResult:
@@ -44,9 +44,9 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			m.connections.manager.Errors[msg.profile.Name] = ""
 			m.refreshConnectionItems()
 			cmd := m.setMode(modeClient)
-			return m, tea.Batch(cmd, listenStatus(m.connections.statusChan))
+			return tea.Batch(cmd, listenStatus(m.connections.statusChan))
 		}
-		return m, listenStatus(m.connections.statusChan)
+		return listenStatus(m.connections.statusChan)
 	case tea.KeyMsg:
 		if m.connections.manager.ConnectionsList.FilterState() == list.Filtering {
 			switch msg.String() {
@@ -60,7 +60,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 						m.connections.manager.Errors[p.Name] = ""
 						m.refreshConnectionItems()
 						cmd := m.setMode(modeClient)
-						return m, cmd
+						return cmd
 					}
 					flushStatus(m.connections.statusChan)
 					if p.FromEnv {
@@ -73,30 +73,30 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
 					m.connections.connection = "Connecting to " + brokerURL
 					m.refreshConnectionItems()
-					return m, connectBroker(p, m.connections.statusChan)
+					return connectBroker(p, m.connections.statusChan)
 				}
 			}
 			break
 		}
 		switch msg.String() {
 		case "ctrl+d":
-			return m, tea.Quit
+			return tea.Quit
 		case "ctrl+r":
 			m.traces.list.SetSize(m.ui.width-4, m.ui.height-4)
 			cmd := m.setMode(modeTracer)
-			return m, cmd
+			return cmd
 		case "a":
 			f := newConnectionForm(Profile{}, -1)
 			m.connections.form = &f
 			cmd := m.setMode(modeEditConnection)
-			return m, cmd
+			return cmd
 		case "e":
 			i := m.connections.manager.ConnectionsList.Index()
 			if i >= 0 && i < len(m.connections.manager.Profiles) {
 				f := newConnectionForm(m.connections.manager.Profiles[i], i)
 				m.connections.form = &f
 				cmd := m.setMode(modeEditConnection)
-				return m, cmd
+				return cmd
 			}
 		case "enter":
 			i := m.connections.manager.ConnectionsList.Index()
@@ -108,7 +108,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					m.connections.manager.Errors[p.Name] = ""
 					m.refreshConnectionItems()
 					cmd := m.setMode(modeClient)
-					return m, cmd
+					return cmd
 				}
 				flushStatus(m.connections.statusChan)
 				if p.FromEnv {
@@ -121,7 +121,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 				brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
 				m.connections.connection = "Connecting to " + brokerURL
 				m.refreshConnectionItems()
-				return m, connectBroker(p, m.connections.statusChan)
+				return connectBroker(p, m.connections.statusChan)
 			}
 		case "delete":
 			i := m.connections.manager.ConnectionsList.Index()
@@ -134,7 +134,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					m.connections.manager.refreshList()
 					m.refreshConnectionItems()
 				})
-				return m, listenStatus(m.connections.statusChan)
+				return listenStatus(m.connections.statusChan)
 			}
 		case "x":
 			if m.mqttClient != nil {
@@ -149,5 +149,5 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 		}
 	}
 	m.connections.manager.ConnectionsList, cmd = m.connections.manager.ConnectionsList.Update(msg)
-	return m, tea.Batch(cmd, listenStatus(m.connections.statusChan))
+	return tea.Batch(cmd, listenStatus(m.connections.statusChan))
 }

--- a/update_form.go
+++ b/update_form.go
@@ -3,9 +3,9 @@ package main
 import tea "github.com/charmbracelet/bubbletea"
 
 // updateForm handles the add/edit connection form.
-func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateForm(msg tea.Msg) tea.Cmd {
 	if m.connections.form == nil {
-		return m, nil
+		return nil
 	}
 	var cmd tea.Cmd
 	switch msg.(type) {
@@ -16,18 +16,18 @@ func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+d":
-			return m, tea.Quit
+			return tea.Quit
 		case "esc":
 			cmd := m.setMode(modeConnections)
 			m.connections.form = nil
-			return m, cmd
+			return cmd
 		case "enter":
 			p, err := m.connections.form.Profile()
 			if err != nil {
 				if m.connections.statusChan != nil {
 					m.connections.statusChan <- err.Error()
 				}
-				return m, listenStatus(m.connections.statusChan)
+				return listenStatus(m.connections.statusChan)
 			}
 			if m.connections.form.index >= 0 {
 				m.connections.manager.EditConnection(m.connections.form.index, p)
@@ -37,10 +37,10 @@ func (m model) updateForm(msg tea.Msg) (model, tea.Cmd) {
 			m.refreshConnectionItems()
 			cmd := m.setMode(modeConnections)
 			m.connections.form = nil
-			return m, cmd
+			return cmd
 		}
 	}
 	f, cmd := m.connections.form.Update(msg)
 	m.connections.form = &f
-	return m, tea.Batch(cmd, listenStatus(m.connections.statusChan))
+	return tea.Batch(cmd, listenStatus(m.connections.statusChan))
 }

--- a/update_history_detail.go
+++ b/update_history_detail.go
@@ -5,18 +5,18 @@ import (
 )
 
 // updateHistoryDetail handles input when viewing a long history payload.
-func (m model) updateHistoryDetail(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateHistoryDetail(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "esc":
 			cmd := m.setMode(modeClient)
-			return m, cmd
+			return cmd
 		case "ctrl+d":
-			return m, tea.Quit
+			return tea.Quit
 		}
 	}
 	m.history.detail, cmd = m.history.detail.Update(msg)
-	return m, cmd
+	return cmd
 }

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -6,9 +6,9 @@ import (
 )
 
 // updateHistoryFilter handles the history filter form interaction.
-func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateHistoryFilter(msg tea.Msg) tea.Cmd {
 	if m.history.filterForm == nil {
-		return m, nil
+		return nil
 	}
 	switch t := msg.(type) {
 	case tea.KeyMsg:
@@ -22,7 +22,7 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 				m.ui.modeStack = m.ui.modeStack[1:]
 			}
 			cmd := tea.Batch(m.setMode(m.currentMode()), m.setFocus(idHistory))
-			return m, cmd
+			return cmd
 		case "enter":
 			q := m.history.filterForm.query()
 			topics, start, end, payload := parseHistoryQuery(q)
@@ -40,10 +40,10 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			m.history.filterQuery = q
 			m.history.filterForm = nil
 			cmd := tea.Batch(m.setMode(m.previousMode()), m.setFocus(idHistory))
-			return m, cmd
+			return cmd
 		}
 	}
 	f, cmd := m.history.filterForm.Update(msg)
 	m.history.filterForm = &f
-	return m, cmd
+	return cmd
 }

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -20,8 +20,7 @@ func TestUpdateHistoryFilter(t *testing.T) {
 	m.history.filterForm.topic.SetValue("foo")
 	m.history.filterForm.start.SetValue("")
 	m.history.filterForm.end.SetValue("")
-	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
-	m = &mv
+	m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
 
 	if len(m.history.list.Items()) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(m.history.list.Items()))
@@ -44,8 +43,7 @@ func TestHistoryFilterPersists(t *testing.T) {
 	m.history.filterForm.topic.SetValue("foo")
 	m.history.filterForm.start.SetValue("")
 	m.history.filterForm.end.SetValue("")
-	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
-	m = &mv
+	m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
 
 	// simulate a subsequent update
 	m.updateClient(nil)
@@ -76,8 +74,7 @@ func TestHistoryFilterUpdatesCounts(t *testing.T) {
 	m.history.filterForm.topic.SetValue("foo")
 	m.history.filterForm.start.SetValue("")
 	m.history.filterForm.end.SetValue("")
-	mv, _ := m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
-	m = &mv
+	m.updateHistoryFilter(tea.KeyMsg{Type: tea.KeyEnter})
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 
 	view := m.viewClient()

--- a/update_importer.go
+++ b/update_importer.go
@@ -5,13 +5,13 @@ import (
 )
 
 // updateImporter forwards messages to the import wizard when active.
-func (m model) updateImporter(msg tea.Msg) (model, tea.Cmd) {
+func (m *model) updateImporter(msg tea.Msg) tea.Cmd {
 	if m.importWizard == nil {
-		return m, nil
+		return nil
 	}
 	nm, cmd := m.importWizard.Update(msg)
 	if w, ok := nm.(*ImportWizard); ok {
 		m.importWizard = w
 	}
-	return m, cmd
+	return cmd
 }


### PR DESCRIPTION
## Summary
- switch stateful update handlers to pointer receivers
- adjust update loop and tests for pointer semantics

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestHistoryPreviewShortMultiline, TestHistoryPreviewShortMultilineCRLF)*

------
https://chatgpt.com/codex/tasks/task_e_688d6c28e6688324b7a38ff0d12e97d6