### PR TITLE
refactor history filtering with helper

### DIFF
--- a/history_util.go
+++ b/history_util.go
@@ -20,3 +20,18 @@ func messagesToHistoryItems(msgs []Message) ([]historyItem, []list.Item) {
 	}
 	return hitems, litems
 }
+
+// applyHistoryFilter parses the query and retrieves matching messages from the store.
+func applyHistoryFilter(q string, store *HistoryStore, archived bool) ([]historyItem, []list.Item) {
+	if store == nil {
+		return nil, nil
+	}
+	topics, start, end, payload := parseHistoryQuery(q)
+	var msgs []Message
+	if archived {
+		msgs = store.SearchArchived(topics, start, end, payload)
+	} else {
+		msgs = store.Search(topics, start, end, payload)
+	}
+	return messagesToHistoryItems(msgs)
+}

--- a/update_client.go
+++ b/update_client.go
@@ -201,25 +201,13 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 
 	if st := m.history.list.FilterState(); st == list.Filtering || st == list.FilterApplied {
 		q := m.history.list.FilterInput.Value()
-		topics, start, end, text := parseHistoryQuery(q)
+		var items []list.Item
+		m.history.items, items = applyHistoryFilter(q, m.history.store, m.history.showArchived)
 		m.history.filterQuery = q
-		var msgs []Message
-		if m.history.showArchived {
-			msgs = m.history.store.SearchArchived(topics, start, end, text)
-		} else {
-			msgs = m.history.store.Search(topics, start, end, text)
-		}
-		_, items := messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)
 	} else if m.history.filterQuery != "" {
-		topics, start, end, text := parseHistoryQuery(m.history.filterQuery)
-		var msgs []Message
-		if m.history.showArchived {
-			msgs = m.history.store.SearchArchived(topics, start, end, text)
-		} else {
-			msgs = m.history.store.Search(topics, start, end, text)
-		}
-		_, items := messagesToHistoryItems(msgs)
+		var items []list.Item
+		m.history.items, items = applyHistoryFilter(m.history.filterQuery, m.history.store, m.history.showArchived)
 		m.history.list.SetItems(items)
 	} else {
 		items := make([]list.Item, len(m.history.items))

--- a/update_history.go
+++ b/update_history.go
@@ -41,15 +41,8 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 	}
 	if !m.history.showArchived {
 		if m.history.filterQuery != "" {
-			topics, start, end, pf := parseHistoryQuery(m.history.filterQuery)
-			var msgs []Message
-			if m.history.showArchived {
-				msgs = m.history.store.SearchArchived(topics, start, end, pf)
-			} else {
-				msgs = m.history.store.Search(topics, start, end, pf)
-			}
 			var items []list.Item
-			m.history.items, items = messagesToHistoryItems(msgs)
+			m.history.items, items = applyHistoryFilter(m.history.filterQuery, m.history.store, m.history.showArchived)
 			m.history.list.SetItems(items)
 			m.history.list.Select(len(items) - 1)
 		} else {


### PR DESCRIPTION
## Summary
- add `applyHistoryFilter` to centralize history searches
- use helper in appendHistory and client update paths

## Testing
- `go vet ./...`
- `go test ./...` *(fails: failed to decode config file, failed to archive message)*

------
https://chatgpt.com/codex/tasks/task_e_688d6c323b8883248d424b4ec125e2a2