### PR TITLE
refactor: unify history search

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -71,9 +71,9 @@ func (m *model) handleClearFilterKey() tea.Cmd {
 	m.history.list.SetFilterState(list.Unfiltered)
 	var msgs []Message
 	if m.history.showArchived {
-		msgs = m.history.store.SearchArchived(nil, time.Time{}, time.Time{}, "")
+		msgs = m.history.store.Search(true, nil, time.Time{}, time.Time{}, "")
 	} else {
-		msgs = m.history.store.Search(nil, time.Time{}, time.Time{}, "")
+		msgs = m.history.store.Search(false, nil, time.Time{}, time.Time{}, "")
 	}
 	var items []list.Item
 	m.history.items, items = messagesToHistoryItems(msgs)

--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -15,9 +15,9 @@ func (m *model) handleToggleArchiveKey() tea.Cmd {
 		m.history.showArchived = !m.history.showArchived
 		var msgs []Message
 		if m.history.showArchived {
-			msgs = m.history.store.SearchArchived(nil, time.Time{}, time.Time{}, "")
+			msgs = m.history.store.Search(true, nil, time.Time{}, time.Time{}, "")
 		} else {
-			msgs = m.history.store.Search(nil, time.Time{}, time.Time{}, "")
+			msgs = m.history.store.Search(false, nil, time.Time{}, time.Time{}, "")
 		}
 		var items []list.Item
 		m.history.items, items = messagesToHistoryItems(msgs)

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -147,7 +147,7 @@ func TestHistoryLabelCounts(t *testing.T) {
 
 	// apply filter showing only "foo"
 	m.history.filterQuery = "topic=foo"
-	msgs := m.history.store.Search([]string{"foo"}, time.Time{}, time.Time{}, "")
+	msgs := m.history.store.Search(false, []string{"foo"}, time.Time{}, time.Time{}, "")
 	var items []list.Item
 	m.history.items, items = messagesToHistoryItems(msgs)
 	m.history.list.SetItems(items)
@@ -243,7 +243,7 @@ func TestDeleteErrorFeedback(t *testing.T) {
 	last := m.history.items[1]
 	if last.kind != "log" || !strings.Contains(last.payload, "Failed to delete") {
 		t.Fatalf("expected delete error log, got %#v", last)
- 	}
+	}
 }
 
 // Test that triggering the detail view shows the complete payload.

--- a/historystore_archive_test.go
+++ b/historystore_archive_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestArchiveAndSearchArchived(t *testing.T) {
+func TestArchiveAndSearch(t *testing.T) {
 	hs := &HistoryStore{}
 	ts := time.Now()
 	msg := Message{Timestamp: ts, Topic: "t1", Payload: "p1", Kind: "pub"}
@@ -15,10 +15,10 @@ func TestArchiveAndSearchArchived(t *testing.T) {
 	if err := hs.Archive(key); err != nil {
 		t.Fatalf("Archive failed: %v", err)
 	}
-	if res := hs.Search([]string{"t1"}, time.Time{}, time.Time{}, ""); len(res) != 0 {
+	if res := hs.Search(false, []string{"t1"}, time.Time{}, time.Time{}, ""); len(res) != 0 {
 		t.Fatalf("expected no active messages, got %d", len(res))
 	}
-	res := hs.SearchArchived([]string{"t1"}, time.Time{}, time.Time{}, "")
+	res := hs.Search(true, []string{"t1"}, time.Time{}, time.Time{}, "")
 	if len(res) != 1 {
 		t.Fatalf("expected 1 archived message, got %d", len(res))
 	}

--- a/historystore_search_test.go
+++ b/historystore_search_test.go
@@ -5,25 +5,50 @@ import (
 	"time"
 )
 
-// Test that HistoryStore.Search respects topic, time, and payload filters.
+// Test that HistoryStore.Search respects topic, time, and payload filters for
+// active and archived messages.
 func TestHistoryStoreSearch(t *testing.T) {
-	hs := &HistoryStore{}
 	now := time.Now()
-	hs.Add(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub"})
-	hs.Add(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub"})
 
-	res := hs.Search([]string{"a"}, now.Add(-1*time.Hour), now, "")
-	if len(res) != 1 || res[0].Topic != "a" {
-		t.Fatalf("topic filter failed: %#v", res)
-	}
+	t.Run("active", func(t *testing.T) {
+		hs := &HistoryStore{}
+		hs.Add(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub"})
+		hs.Add(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub"})
 
-	res = hs.Search(nil, now.Add(-1*time.Hour), now, "foo")
-	if len(res) != 1 || res[0].Payload != "foo" {
-		t.Fatalf("payload filter failed: %#v", res)
-	}
+		res := hs.Search(false, []string{"a"}, now.Add(-1*time.Hour), now, "")
+		if len(res) != 1 || res[0].Topic != "a" {
+			t.Fatalf("topic filter failed: %#v", res)
+		}
 
-	res = hs.Search([]string{"b"}, now.Add(-1*time.Hour), now, "")
-	if len(res) != 0 {
-		t.Fatalf("time filter failed: %#v", res)
-	}
+		res = hs.Search(false, nil, now.Add(-1*time.Hour), now, "foo")
+		if len(res) != 1 || res[0].Payload != "foo" {
+			t.Fatalf("payload filter failed: %#v", res)
+		}
+
+		res = hs.Search(false, []string{"b"}, now.Add(-1*time.Hour), now, "")
+		if len(res) != 0 {
+			t.Fatalf("time filter failed: %#v", res)
+		}
+	})
+
+	t.Run("archived", func(t *testing.T) {
+		hs := &HistoryStore{}
+		hs.Add(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true})
+		hs.Add(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true})
+
+		res := hs.Search(true, []string{"a"}, now.Add(-1*time.Hour), now, "")
+		if len(res) != 1 || res[0].Topic != "a" {
+			t.Fatalf("topic filter failed: %#v", res)
+		}
+
+		res = hs.Search(true, nil, now.Add(-1*time.Hour), now, "foo")
+		if len(res) != 1 || res[0].Payload != "foo" {
+			t.Fatalf("payload filter failed: %#v", res)
+		}
+
+		res = hs.Search(true, []string{"b"}, now.Add(-1*time.Hour), now, "")
+		if len(res) != 0 {
+			t.Fatalf("time filter failed: %#v", res)
+		}
+	})
 }

--- a/model_init.go
+++ b/model_init.go
@@ -196,7 +196,7 @@ func initialModel(conns *Connections) (*model, error) {
 	m.traces.view.SetDelegate(traceDel)
 	if idx, err := openHistoryStore(""); err == nil {
 		m.history.store = idx
-		msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
+		msgs := idx.Search(false, nil, time.Time{}, time.Time{}, "")
 		var items []list.Item
 		m.history.items, items = messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)

--- a/update_client.go
+++ b/update_client.go
@@ -205,9 +205,9 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		m.history.filterQuery = q
 		var msgs []Message
 		if m.history.showArchived {
-			msgs = m.history.store.SearchArchived(topics, start, end, text)
+			msgs = m.history.store.Search(true, topics, start, end, text)
 		} else {
-			msgs = m.history.store.Search(topics, start, end, text)
+			msgs = m.history.store.Search(false, topics, start, end, text)
 		}
 		_, items := messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)
@@ -215,9 +215,9 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		topics, start, end, text := parseHistoryQuery(m.history.filterQuery)
 		var msgs []Message
 		if m.history.showArchived {
-			msgs = m.history.store.SearchArchived(topics, start, end, text)
+			msgs = m.history.store.Search(true, topics, start, end, text)
 		} else {
-			msgs = m.history.store.Search(topics, start, end, text)
+			msgs = m.history.store.Search(false, topics, start, end, text)
 		}
 		_, items := messagesToHistoryItems(msgs)
 		m.history.list.SetItems(items)

--- a/update_connections.go
+++ b/update_connections.go
@@ -28,7 +28,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 			}
 			if idx, err := openHistoryStore(msg.profile.Name); err == nil {
 				m.history.store = idx
-				msgs := idx.Search(nil, time.Time{}, time.Time{}, "")
+				msgs := idx.Search(false, nil, time.Time{}, time.Time{}, "")
 				m.history.items = nil
 				items := make([]list.Item, len(msgs))
 				for i, mmsg := range msgs {

--- a/update_history.go
+++ b/update_history.go
@@ -44,9 +44,9 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 			topics, start, end, pf := parseHistoryQuery(m.history.filterQuery)
 			var msgs []Message
 			if m.history.showArchived {
-				msgs = m.history.store.SearchArchived(topics, start, end, pf)
+				msgs = m.history.store.Search(true, topics, start, end, pf)
 			} else {
-				msgs = m.history.store.Search(topics, start, end, pf)
+				msgs = m.history.store.Search(false, topics, start, end, pf)
 			}
 			var items []list.Item
 			m.history.items, items = messagesToHistoryItems(msgs)

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -28,9 +28,9 @@ func (m model) updateHistoryFilter(msg tea.Msg) (model, tea.Cmd) {
 			topics, start, end, payload := parseHistoryQuery(q)
 			var msgs []Message
 			if m.history.showArchived {
-				msgs = m.history.store.SearchArchived(topics, start, end, payload)
+				msgs = m.history.store.Search(true, topics, start, end, payload)
 			} else {
-				msgs = m.history.store.Search(topics, start, end, payload)
+				msgs = m.history.store.Search(false, topics, start, end, payload)
 			}
 			var items []list.Item
 			m.history.items, items = messagesToHistoryItems(msgs)


### PR DESCRIPTION
## Summary
- expose HistoryStore.Search(archived bool, ...) for both active and archived lookups
- update call sites to pass archived flag
- expand history search tests to cover archived and active messages

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestHistoryPreviewShortMultiline, TestHistoryPreviewShortMultilineCRLF)*

------
https://chatgpt.com/codex/tasks/task_e_688d6c2388b08324a9de7aadf4a57970