### PR TITLE
fix import wizard field references

### DIFF
--- a/importer_wizard_map.go
+++ b/importer_wizard_map.go
@@ -55,10 +55,10 @@ func (w *ImportWizard) viewMap(bw, _ int) string {
 	var b strings.Builder
 	for i, h := range w.headers {
 		label := h
-		if i == w.form.focus {
+		if i == w.form.Focus {
 			label = ui.FocusedStyle.Render(h)
 		}
-		fmt.Fprintf(&b, "%*s : %s\n", colw, label, w.form.fields[i].View())
+		fmt.Fprintf(&b, "%*s : %s\n", colw, label, w.form.Fields[i].View())
 	}
 	b.WriteString("\nUse a.b to nest fields\n[enter] continue  [ctrl+n] next  [ctrl+p] back")
 	return ui.LegendBox(b.String(), "Map Columns", bw, 0, ui.ColBlue, true, -1)


### PR DESCRIPTION
## Summary
- fix importer wizard to use exported form field names

## Testing
- `go vet ./...`
- `go test ./...`
- `go build .`


------
https://chatgpt.com/codex/tasks/task_e_688dcc23b0d88324851391c508c8fd95